### PR TITLE
Updates to mathml package

### DIFF
--- a/skema/skema-rs/mathml/src/graph.rs
+++ b/skema/skema-rs/mathml/src/graph.rs
@@ -1,7 +1,8 @@
 use crate::ast::{
     Math, MathExpression,
     MathExpression::{
-        Mfrac, Mi, Mn, Mo, Mover, Mrow, Msqrt, Msub, Msubsup, Msup, Mtext, Mstyle, Munder, Mspace, MoLine,
+        Mfrac, Mi, Mn, Mo, MoLine, Mover, Mrow, Mspace, Msqrt, Mstyle, Msub, Msubsup, Msup, Mtext,
+        Munder,
     },
 };
 
@@ -9,145 +10,72 @@ use petgraph::{graph::NodeIndex, Graph};
 
 pub type MathMLGraph<'a> = Graph<&'a str, u32>;
 
+fn add_node_and_edge<'a>(
+    graph: &mut MathMLGraph<'a>,
+    parent_index: Option<NodeIndex>,
+    x: &'a str,
+) -> NodeIndex {
+    let node_index = graph.add_node(x);
+    if let Some(p) = parent_index {
+        graph.add_edge(p, node_index, 1);
+    }
+    node_index
+}
+
+fn add_to_graph_0<'a>(graph: &mut MathMLGraph<'a>, parent_index: Option<NodeIndex>, x: &'a str) {
+    add_node_and_edge(graph, parent_index, x);
+}
+
+/// Update the parent index
+fn update_parent<'a>(
+    graph: &mut MathMLGraph<'a>,
+    mut parent_index: Option<NodeIndex>,
+    x: &'a str,
+) -> Option<NodeIndex> {
+    let node_index = add_node_and_edge(graph, parent_index, x);
+    parent_index = Some(node_index);
+    parent_index
+}
+
+/// Macro to add elements with fixed numbers of child elements.
+macro_rules! add_to_graph_n {
+    ($graph: ident, $parent_index: ident, $elem_type: literal, $($x:ident),+ ) => {{
+            let parent_index = update_parent($graph, $parent_index, $elem_type);
+            $( $x.add_to_graph($graph, parent_index); )+
+    }}
+}
+
+/// Function to add elements with a variable number of child elements.
+fn add_to_graph_many0<'a>(
+    graph: &mut MathMLGraph<'a>,
+    parent_index: Option<NodeIndex>,
+    elem_type: &'a str,
+    elements: &Vec<MathExpression<'a>>,
+) {
+    let parent_index = update_parent(graph, parent_index, elem_type);
+    for element in elements {
+        element.add_to_graph(graph, parent_index);
+    }
+}
+
 impl<'a> MathExpression<'a> {
-    pub fn add_to_graph(&self, graph: &mut MathMLGraph<'a>, mut parent_index: Option<NodeIndex>) {
+    pub fn add_to_graph(&self, graph: &mut MathMLGraph<'a>, parent_index: Option<NodeIndex>) {
         match self {
-            Mi(x) => {
-                let node_index = graph.add_node(x);
-                if let Some(p) = parent_index {
-                    graph.add_edge(p, node_index, 1);
-                }
-            }
-            Mo(x) => {
-                let node_index = graph.add_node(x);
-                if let Some(p) = parent_index {
-                    graph.add_edge(p, node_index, 1);
-                }
-            }
-            Mn(x) => {
-                let node_index = graph.add_node(x);
-                if let Some(p) = parent_index {
-                    graph.add_edge(p, node_index, 1);
-                }
-            }
-
-            Msqrt(contents) => {
-                let node_index = graph.add_node("msqrt");
-                if let Some(p) = parent_index {
-                    graph.add_edge(p, node_index, 1);
-                }
-                parent_index = Some(node_index);
-                contents.add_to_graph(graph, parent_index);
-            }
-
-            Msup(base, superscript) => {
-                let node_index = graph.add_node("msup");
-                if let Some(p) = parent_index {
-                    graph.add_edge(p, node_index, 1);
-                }
-                parent_index = Some(node_index);
-                base.add_to_graph(graph, parent_index);
-                superscript.add_to_graph(graph, parent_index);
-            }
-
-            Msub(base, subscript) => {
-                let node_index = graph.add_node("msub");
-                if let Some(p) = parent_index {
-                    graph.add_edge(p, node_index, 1);
-                }
-                parent_index = Some(node_index);
-                base.add_to_graph(graph, parent_index);
-                subscript.add_to_graph(graph, parent_index);
-            }
-
-            Mfrac(numerator, denominator) => {
-                let node_index = graph.add_node("mfrac");
-                if let Some(p) = parent_index {
-                    graph.add_edge(p, node_index, 1);
-                }
-                parent_index = Some(node_index);
-                numerator.add_to_graph(graph, parent_index);
-                denominator.add_to_graph(graph, parent_index);
-            }
-
-            Mrow(elements) => {
-                let node_index = graph.add_node("mrow");
-                if let Some(p) = parent_index {
-                    graph.add_edge(p, node_index, 1);
-                }
-                parent_index = Some(node_index);
-                for element in elements {
-                    element.add_to_graph(graph, parent_index);
-                }
-            }
-
-            Munder(elements) => {
-                let node_index = graph.add_node("munder");
-                if let Some(p) = parent_index {
-                    graph.add_edge(p, node_index, 1);
-                }
-                parent_index = Some(node_index);
-                for element in elements {
-                    element.add_to_graph(graph, parent_index);
-                }
-            }
-
-            Mover(elements) => {
-                let node_index = graph.add_node("mover");
-                if let Some(p) = parent_index {
-                    graph.add_edge(p, node_index, 1);
-                }
-                parent_index = Some(node_index);
-                for element in elements {
-                    element.add_to_graph(graph, parent_index);
-                }
-            }
-
-            Msubsup(elements) => {
-                let node_index = graph.add_node("msubsup");
-                if let Some(p) = parent_index {
-                    graph.add_edge(p, node_index, 1);
-                }
-                parent_index = Some(node_index);
-                for element in elements {
-                    element.add_to_graph(graph, parent_index);
-                }
-            }
-
-            Mtext(x) => {
-                let node_index = graph.add_node(x);
-                if let Some(p) = parent_index {
-                    graph.add_edge(p, node_index, 1);
-                }
-            }
-
-	    
-	    Mstyle(elements) => {
-                let node_index = graph.add_node("mrow");
-                if let Some(p) = parent_index {
-                    graph.add_edge(p, node_index, 1);
-                }
-                parent_index = Some(node_index);
-                for element in elements {
-                    element.add_to_graph(graph, parent_index);
-                }
-            }
-	    
-	    Mspace(x) => {
-                let node_index = graph.add_node(x);
-                if let Some(p) = parent_index {
-                    graph.add_edge(p, node_index, 1);
-                }
-            }
-
-	    MoLine(x) => {
-                let node_index = graph.add_node(x);
-                if let Some(p) = parent_index {
-                    graph.add_edge(p, node_index, 1);
-                }
-            }
-
-
+            Mi(x) => add_to_graph_0(graph, parent_index, x),
+            Mo(x) => add_to_graph_0(graph, parent_index, x),
+            Mn(x) => add_to_graph_0(graph, parent_index, x),
+            Msqrt(x) => add_to_graph_n!(graph, parent_index, "msqrt", x),
+            Msup(x1, x2) => add_to_graph_n!(graph, parent_index, "msup", x1, x2),
+            Msub(x1, x2) => add_to_graph_n!(graph, parent_index, "msub", x1, x2),
+            Mfrac(x1, x2) => add_to_graph_n!(graph, parent_index, "mfrac", x1, x2),
+            Mrow(xs) => add_to_graph_many0(graph, parent_index, "mrow", xs),
+            Munder(xs) => add_to_graph_many0(graph, parent_index, "munder", xs),
+            Mover(xs) => add_to_graph_many0(graph, parent_index, "mover", xs),
+            Msubsup(xs) => add_to_graph_many0(graph, parent_index, "msubsup", xs),
+            Mtext(x) => add_to_graph_0(graph, parent_index, x),
+            Mstyle(xs) => add_to_graph_many0(graph, parent_index, "mstyle", xs),
+            Mspace(x) => add_to_graph_0(graph, parent_index, x),
+            MoLine(x) => add_to_graph_0(graph, parent_index, x),
         }
     }
 }

--- a/skema/skema-rs/mathml/src/parsing.rs
+++ b/skema/skema-rs/mathml/src/parsing.rs
@@ -1,19 +1,19 @@
 use crate::ast::{
     Math, MathExpression,
     MathExpression::{
-        Mfrac, Mi, Mn, Mo, Mover, Mrow, Msqrt, Msub, Msubsup, Msup, Mtext, Mstyle, Munder, Mspace, MoLine,
+        Mfrac, Mi, Mn, Mo, MoLine, Mover, Mrow, Mspace, Msqrt, Mstyle, Msub, Msubsup, Msup, Mtext,
+        Munder,
     },
 };
 use nom::{
     branch::alt,
     bytes::complete::{tag, take_until},
     character::complete::{alphanumeric1, multispace0},
-    combinator::{map,opt},
+    combinator::{map, opt},
     multi::many0,
-    sequence::{delimited, pair, separated_pair, tuple, preceded},
+    sequence::{delimited, pair, preceded, separated_pair, tuple},
 };
 use nom_locate::LocatedSpan;
-use std::fs;
 
 type Span<'a> = LocatedSpan<&'a str>;
 
@@ -237,21 +237,8 @@ fn mo_line(input: Span) -> IResult<MathExpression> {
 /// Math expressions
 fn math_expression(input: Span) -> IResult<MathExpression> {
     ws(alt((
-        mi,
-        mo,
-        mn,
-        msup,
-        msub,
-        msqrt,
-        mfrac,
-        mrow,
-        munder,
-        mover,
-        msubsup,
-        mtext,
-	mstyle,
-        mspace,
-	mo_line,
+        mi, mo, mn, msup, msub, msqrt, mfrac, mrow, munder, mover, msubsup, mtext, mstyle, mspace,
+        mo_line,
     )))(input)
 }
 
@@ -346,7 +333,7 @@ fn test_munder() {
 #[test]
 fn test_msubsup() {
     test_parser(
-	"<msubsup><mi>L</mi><mi>t</mi><mi>∞</mi></msubsup>",
+        "<msubsup><mi>L</mi><mi>t</mi><mi>∞</mi></msubsup>",
         msubsup,
         Msubsup(vec![Mi("L"), Mi("t"), Mi("∞")]),
     )
@@ -360,7 +347,7 @@ fn test_mtext() {
 #[test]
 fn test_mstyle() {
     test_parser(
-	"<mstyle><mo>∑</mo><mi>I</mi></mstyle>",
+        "<mstyle><mo>∑</mo><mi>I</mi></mstyle>",
         mstyle,
         Mstyle(vec![Mo("∑"), Mi("I")]),
     )
@@ -373,9 +360,12 @@ fn test_mspace() {
 
 #[test]
 fn test_moline() {
-    test_parser("<mo fence=\"true\" stretchy=\"true\" symmetric=\"true\"/>", mo_line, MoLine(" fence=\"true\" stretchy=\"true\" symmetric=\"true\""));
+    test_parser(
+        "<mo fence=\"true\" stretchy=\"true\" symmetric=\"true\"/>",
+        mo_line,
+        MoLine(" fence=\"true\" stretchy=\"true\" symmetric=\"true\""),
+    );
 }
-
 
 #[test]
 fn test_math() {
@@ -394,21 +384,43 @@ fn test_math() {
 }
 
 #[test]
-fn test_mathml_parser(){
-    let eqn = fs::read_to_string("tests/test01.xml").unwrap();
+fn test_mathml_parser() {
+    let eqn = std::fs::read_to_string("tests/test01.xml").unwrap();
     test_parser(
-	&eqn,
-    	math,
-    	Math{
-	    content: vec![Munder( vec![Mo("sup"), Mrow(vec![Mn("0"), Mo("≤"), Mi("t"), Mo("≤"), Msub(Box::new(Mi("T")),Box::new(Mn("0")) ) ]) ]  ) ,
-	    	          Mo("‖"),
-			  Msup(Box::new(Mrow(vec![Mover(vec![Mi("ρ"), Mo("~")])])),Box::new(Mi("R")) ),
-			  Msup(Box::new(Mrow(vec![Mover(vec![Mi("x"), Mo("¯")])])),Box::new(Mi("a")) ),
-			  Msub(Box::new(Mo("‖")),Box::new(Mrow(vec![Msup(Box::new(Mi("L")),Box::new(Mn("1"))), Mo("∩"), Msup(Box::new(Mi("L")),Box::new(Mi("∞")))]))), 
-			  Mo("≤"),
-			  Mi("C"),
-			 ],
+        &eqn,
+        math,
+        Math {
+            content: vec![
+                Munder(vec![
+                    Mo("sup"),
+                    Mrow(vec![
+                        Mn("0"),
+                        Mo("≤"),
+                        Mi("t"),
+                        Mo("≤"),
+                        Msub(Box::new(Mi("T")), Box::new(Mn("0"))),
+                    ]),
+                ]),
+                Mo("‖"),
+                Msup(
+                    Box::new(Mrow(vec![Mover(vec![Mi("ρ"), Mo("~")])])),
+                    Box::new(Mi("R")),
+                ),
+                Msup(
+                    Box::new(Mrow(vec![Mover(vec![Mi("x"), Mo("¯")])])),
+                    Box::new(Mi("a")),
+                ),
+                Msub(
+                    Box::new(Mo("‖")),
+                    Box::new(Mrow(vec![
+                        Msup(Box::new(Mi("L")), Box::new(Mn("1"))),
+                        Mo("∩"),
+                        Msup(Box::new(Mi("L")), Box::new(Mi("∞"))),
+                    ])),
+                ),
+                Mo("≤"),
+                Mi("C"),
+            ],
         },
     )
 }
-

--- a/skema/skema-rs/mathml/tests/test01.xml
+++ b/skema/skema-rs/mathml/tests/test01.xml
@@ -1,51 +1,51 @@
 <?xml version="1.0" ?>
 <math>
-	<munder>
-		<mo form="prefix">sup</mo>
-		<mrow>
-			<mn>0</mn>
-			<mo>≤</mo>
-			<mi>t</mi>
-			<mo>≤</mo>
-			<msub>
-				<mi>T</mi>
-				<mn>0</mn>
-			</msub>
-		</mrow>
-	</munder>
-	<mo fence="false">‖</mo>
-	<msup>
-		<mrow>
-			<mover>
-				<mi>ρ</mi>
-				<mo>~</mo>
-			</mover>
-		</mrow>
-		<mi>R</mi>
-	</msup>
-	<msup>
-		<mrow>
-			<mover>
-				<mi>x</mi>
-				<mo>¯</mo>
-			</mover>
-		</mrow>
-		<mi>a</mi>
-	</msup>
-	<msub>
-		<mo fence="false">‖</mo>
-		<mrow>
-			<msup>
-				<mi>L</mi>
-				<mn>1</mn>
-			</msup>
-			<mo>∩</mo>
-			<msup>
-				<mi>L</mi>
-				<mi>∞</mi>
-			</msup>
-		</mrow>
-	</msub>
-	<mo>≤</mo>
-	<mi>C</mi>
+    <munder>
+        <mo form="prefix">sup</mo>
+        <mrow>
+            <mn>0</mn>
+            <mo>≤</mo>
+            <mi>t</mi>
+            <mo>≤</mo>
+            <msub>
+                <mi>T</mi>
+                <mn>0</mn>
+            </msub>
+        </mrow>
+    </munder>
+    <mo fence="false">‖</mo>
+    <msup>
+        <mrow>
+            <mover>
+                <mi>ρ</mi>
+                <mo>~</mo>
+            </mover>
+        </mrow>
+        <mi>R</mi>
+    </msup>
+    <msup>
+        <mrow>
+            <mover>
+                <mi>x</mi>
+                <mo>¯</mo>
+            </mover>
+        </mrow>
+        <mi>a</mi>
+    </msup>
+    <msub>
+        <mo fence="false">‖</mo>
+        <mrow>
+            <msup>
+                <mi>L</mi>
+                <mn>1</mn>
+            </msup>
+            <mo>∩</mo>
+            <msup>
+                <mi>L</mi>
+                <mi>∞</mi>
+            </msup>
+        </mrow>
+    </msub>
+    <mo>≤</mo>
+    <mi>C</mi>
 </math>


### PR DESCRIPTION
This PR implements a couple of small changes to the `mathml` package:

- Reduces code duplication in `graph.rs`
- Autoformats `parsing.rs` and removes unused import
- Changes tabs to spaces in `test01.xml`