### PR TITLE
Subscript collapsing

### DIFF
--- a/skema/skema-rs/mathml/src/ast.rs
+++ b/skema/skema-rs/mathml/src/ast.rs
@@ -1,24 +1,24 @@
 #[derive(Debug, PartialEq, Clone)]
-pub enum MathExpression<'a> {
-    Mi(&'a str),
-    Mo(&'a str),
-    Mn(&'a str),
-    Msqrt(Box<MathExpression<'a>>),
-    Mrow(Vec<MathExpression<'a>>),
-    Mfrac(Box<MathExpression<'a>>, Box<MathExpression<'a>>),
-    Msup(Box<MathExpression<'a>>, Box<MathExpression<'a>>),
-    Msub(Box<MathExpression<'a>>, Box<MathExpression<'a>>),
-    Munder(Vec<MathExpression<'a>>),
-    Mover(Vec<MathExpression<'a>>),
-    Msubsup(Vec<MathExpression<'a>>),
-    Mtext(&'a str),
-    Mstyle(Vec<MathExpression<'a>>),
-    Mspace(&'a str),
-    MoLine(&'a str),
+pub enum MathExpression {
+    Mi(String),
+    Mo(String),
+    Mn(String),
+    Msqrt(Box<MathExpression>),
+    Mrow(Vec<MathExpression>),
+    Mfrac(Box<MathExpression>, Box<MathExpression>),
+    Msup(Box<MathExpression>, Box<MathExpression>),
+    Msub(Box<MathExpression>, Box<MathExpression>),
+    Munder(Vec<MathExpression>),
+    Mover(Vec<MathExpression>),
+    Msubsup(Vec<MathExpression>),
+    Mtext(String),
+    Mstyle(Vec<MathExpression>),
+    Mspace(String),
+    MoLine(String),
 }
 
 #[derive(Debug, PartialEq)]
-pub struct Math<'a> {
-    pub content: Vec<MathExpression<'a>>,
+pub struct Math {
+    pub content: Vec<MathExpression>,
 }
 

--- a/skema/skema-rs/mathml/src/bin/parse_mathml.rs
+++ b/skema/skema-rs/mathml/src/bin/parse_mathml.rs
@@ -15,7 +15,8 @@ fn main() {
     let input = &args.input;
     let contents =
         std::fs::read_to_string(input).expect(format!("Unable to read file {input}!").as_str());
-    let (_, math) = parse(&contents).expect(format!("Unable to parse file {input}!").as_str());
+    let (_, mut math) = parse(&contents).expect(format!("Unable to parse file {input}!").as_str());
+    math.normalize();
     let g = math.to_graph();
     println!("{}", Dot::with_config(&g, &[Config::EdgeNoLabel]));
 }

--- a/skema/skema-rs/mathml/src/graph.rs
+++ b/skema/skema-rs/mathml/src/graph.rs
@@ -50,7 +50,7 @@ fn add_to_graph_many0<'a>(
     graph: &mut MathMLGraph<'a>,
     parent_index: Option<NodeIndex>,
     elem_type: &'a str,
-    elements: &Vec<MathExpression<'a>>,
+    elements: &'a Vec<MathExpression>,
 ) {
     let parent_index = update_parent(graph, parent_index, elem_type);
     for element in elements {
@@ -58,8 +58,8 @@ fn add_to_graph_many0<'a>(
     }
 }
 
-impl<'a> MathExpression<'a> {
-    pub fn add_to_graph(&self, graph: &mut MathMLGraph<'a>, parent_index: Option<NodeIndex>) {
+impl MathExpression {
+    pub fn add_to_graph<'a>(&'a self, graph: &mut MathMLGraph<'a>, parent_index: Option<NodeIndex>) {
         match self {
             Mi(x) => add_to_graph_0(graph, parent_index, x),
             Mo(x) => add_to_graph_0(graph, parent_index, x),
@@ -80,7 +80,7 @@ impl<'a> MathExpression<'a> {
     }
 }
 
-impl<'a> Math<'a> {
+impl Math {
     pub fn to_graph(&self) -> MathMLGraph {
         let mut g = MathMLGraph::new();
         let root_index = g.add_node("root");

--- a/skema/skema-rs/mathml/src/graph.rs
+++ b/skema/skema-rs/mathml/src/graph.rs
@@ -13,7 +13,7 @@ pub type MathMLGraph<'a> = Graph<&'a str, u32>;
 fn add_node_and_edge<'a>(
     graph: &mut MathMLGraph<'a>,
     parent_index: Option<NodeIndex>,
-    x: &str,
+    x: &'a str,
 ) -> NodeIndex {
     let node_index = graph.add_node(x);
     if let Some(p) = parent_index {
@@ -22,7 +22,7 @@ fn add_node_and_edge<'a>(
     node_index
 }
 
-fn add_to_graph_0<'a>(graph: &mut MathMLGraph, parent_index: Option<NodeIndex>, x: &str) {
+fn add_to_graph_0<'a>(graph: &mut MathMLGraph<'a>, parent_index: Option<NodeIndex>, x: &'a str) {
     add_node_and_edge(graph, parent_index, x);
 }
 
@@ -30,7 +30,7 @@ fn add_to_graph_0<'a>(graph: &mut MathMLGraph, parent_index: Option<NodeIndex>, 
 fn update_parent<'a>(
     graph: &mut MathMLGraph<'a>,
     mut parent_index: Option<NodeIndex>,
-    x: &str,
+    x: &'a str,
 ) -> Option<NodeIndex> {
     let node_index = add_node_and_edge(graph, parent_index, x);
     parent_index = Some(node_index);
@@ -49,8 +49,8 @@ macro_rules! add_to_graph_n {
 fn add_to_graph_many0<'a>(
     graph: &mut MathMLGraph<'a>,
     parent_index: Option<NodeIndex>,
-    elem_type: &str,
-    elements: &Vec<MathExpression>,
+    elem_type: &'a str,
+    elements: &Vec<MathExpression<'a>>,
 ) {
     let parent_index = update_parent(graph, parent_index, elem_type);
     for element in elements {

--- a/skema/skema-rs/mathml/src/graph.rs
+++ b/skema/skema-rs/mathml/src/graph.rs
@@ -13,7 +13,7 @@ pub type MathMLGraph<'a> = Graph<&'a str, u32>;
 fn add_node_and_edge<'a>(
     graph: &mut MathMLGraph<'a>,
     parent_index: Option<NodeIndex>,
-    x: &'a str,
+    x: &str,
 ) -> NodeIndex {
     let node_index = graph.add_node(x);
     if let Some(p) = parent_index {
@@ -22,7 +22,7 @@ fn add_node_and_edge<'a>(
     node_index
 }
 
-fn add_to_graph_0<'a>(graph: &mut MathMLGraph<'a>, parent_index: Option<NodeIndex>, x: &'a str) {
+fn add_to_graph_0<'a>(graph: &mut MathMLGraph, parent_index: Option<NodeIndex>, x: &str) {
     add_node_and_edge(graph, parent_index, x);
 }
 
@@ -30,7 +30,7 @@ fn add_to_graph_0<'a>(graph: &mut MathMLGraph<'a>, parent_index: Option<NodeInde
 fn update_parent<'a>(
     graph: &mut MathMLGraph<'a>,
     mut parent_index: Option<NodeIndex>,
-    x: &'a str,
+    x: &str,
 ) -> Option<NodeIndex> {
     let node_index = add_node_and_edge(graph, parent_index, x);
     parent_index = Some(node_index);
@@ -49,8 +49,8 @@ macro_rules! add_to_graph_n {
 fn add_to_graph_many0<'a>(
     graph: &mut MathMLGraph<'a>,
     parent_index: Option<NodeIndex>,
-    elem_type: &'a str,
-    elements: &Vec<MathExpression<'a>>,
+    elem_type: &str,
+    elements: &Vec<MathExpression>,
 ) {
     let parent_index = update_parent(graph, parent_index, elem_type);
     for element in elements {

--- a/skema/skema-rs/mathml/src/lib.rs
+++ b/skema/skema-rs/mathml/src/lib.rs
@@ -3,3 +3,4 @@
 pub mod ast;
 pub mod graph;
 pub mod parsing;
+pub mod normalization;

--- a/skema/skema-rs/mathml/src/normalization.rs
+++ b/skema/skema-rs/mathml/src/normalization.rs
@@ -1,11 +1,11 @@
+use crate::parsing::parse;
 use crate::ast::{
     Math, MathExpression,
     MathExpression::{
-        Mfrac, Mi, Mn, Mo, MoLine, Mover, Mrow, Mspace, Msqrt, Mstyle, Msub, Msubsup, Msup, Mtext,
-        Munder,
+        Mi, Mn, Mo, Mrow, Msub,
     },
 };
-use crate::parsing::parse;
+
 
 impl MathExpression {
     /// Collapse subscripts
@@ -15,7 +15,7 @@ impl MathExpression {
                 let mut combined = String::from(&base.get_string_repr());
                 combined.push_str("_{");
                 combined.push_str(&subscript.get_string_repr());
-                combined.push_str("}");
+                combined.push('}');
                 *self = Mi(combined);
             }
 

--- a/skema/skema-rs/mathml/src/normalization.rs
+++ b/skema/skema-rs/mathml/src/normalization.rs
@@ -10,12 +10,11 @@ use crate::ast::{
 
 
 impl<'a> MathExpression<'a> {
-    fn collapse_subscripts(&self) -> Option<MathExpression> {
+    fn collapse_subscripts(&self, storage: &'a str) -> Option<MathExpression> {
         match self {
             Msub(base, subscript) => {
-                let storage = String::new();
-                storage.push_str(&base.get_string_repr());
-                storage.push_str(&subscript.get_string_repr());
+                storage.to_owned().push_str(&base.get_string_repr());
+                storage.to_owned().push_str(&subscript.get_string_repr());
                 Some(Mi(storage))
             }
             _ => None
@@ -57,5 +56,5 @@ fn test_get_string_repr() {
 fn test_subscript_collapsing() {
     let expr = Msub(Box::new(Mi("S")), Box::new(Mrow(vec![Mi("t"), Mo("+"), Mi("1")])));
     let mut storage = String::new();
-    assert_eq!(expr.collapse_subscripts().unwrap(), Mi("St+1"));
+    assert_eq!(expr.collapse_subscripts(&storage).unwrap(), Mi("St+1"));
 }

--- a/skema/skema-rs/mathml/src/normalization.rs
+++ b/skema/skema-rs/mathml/src/normalization.rs
@@ -8,35 +8,44 @@ use crate::ast::{
 use crate::parsing::parse;
 
 impl MathExpression {
+    /// Collapse subscripts
     fn collapse_subscripts(&mut self) {
         match self {
             Msub(base, subscript) => {
                 let mut combined = String::from(&base.get_string_repr());
+                combined.push_str("_{");
                 combined.push_str(&subscript.get_string_repr());
+                combined.push_str("}");
                 *self = Mi(combined);
-                //Some(Mi(combined))
             }
-            //Mn(x) => add_to_graph_0(graph, parent_index, x),
-            //Msqrt(x) => add_to_graph_n!(graph, parent_index, "msqrt", x),
-            //Msup(x1, x2) => add_to_graph_n!(graph, parent_index, "msup", x1, x2),
-            //Msub(x1, x2) => add_to_graph_n!(graph, parent_index, "msub", x1, x2),
-            //Mfrac(x1, x2) => add_to_graph_n!(graph, parent_index, "mfrac", x1, x2),
-            //Mrow(xs) => add_to_graph_many0(graph, parent_index, "mrow", xs),
-            //Munder(xs) => add_to_graph_many0(graph, parent_index, "munder", xs),
-            //Mover(xs) => add_to_graph_many0(graph, parent_index, "mover", xs),
-            //Msubsup(xs) => add_to_graph_many0(graph, parent_index, "msubsup", xs),
-            //Mtext(x) => add_to_graph_0(graph, parent_index, x),
-            //Mstyle(xs) => add_to_graph_many0(graph, parent_index, "mstyle", xs),
-            //Mspace(x) => add_to_graph_0(graph, parent_index, x),
-            //MoLine(x) => add_to_graph_0(graph, parent_index, x),
+
+            Mrow(xs) => {
+                for x in xs {
+                    x.collapse_subscripts();
+                }
+            }
             _ => (),
         }
     }
 
+    /// Collapse mrow elements that only have one child element.
+    fn collapse_mrows(&mut self) {
+        match self {
+            Mrow(xs) => {
+                if xs.len() == 1 {
+                    *self = xs[0].clone();
+                }
+            }
+            _ => (),
+        }
+    }
+
+    /// Get the string representation of a MathExpression
     fn get_string_repr(&self) -> String {
         match self {
             Mi(x) => x.to_string(),
             Mo(x) => x.to_string(),
+            Mn(x) => x.to_string(),
             Mrow(xs) => xs
                 .iter()
                 .map(|x| x.get_string_repr())
@@ -49,12 +58,17 @@ impl MathExpression {
     }
 }
 
-fn normalize(math: &mut Math) {
-    for expr in &mut math.content {
-        expr.collapse_subscripts();
+impl Math {
+    /// Normalize the math expression, performing the following steps:
+    /// 1. Collapse mrows containing only one child element.
+    /// 2. Collapse subscripts assuming we don't need their substructure.
+    pub fn normalize(&mut self) {
+        for expr in &mut self.content {
+            expr.collapse_mrows();
+            expr.collapse_subscripts();
+        }
     }
 }
-
 #[test]
 fn test_get_string_repr() {
     assert_eq!(Mi("t".to_string()).get_string_repr(), "t".to_string());
@@ -76,21 +90,24 @@ fn test_subscript_collapsing() {
         ])),
     );
     expr.collapse_subscripts();
-    assert_eq!(expr, Mi("St+1".to_string()));
+    assert_eq!(expr, Mi("S_{t+1}".to_string()));
 }
 
 #[test]
 fn test_normalize() {
-    let mut math = Math {
-        content: vec![Msub(
-            Box::new(Mi("S".to_string())),
-            Box::new(Mrow(vec![
-                Mi("t".to_string()),
-                Mo("+".to_string()),
-                Mi("1".to_string()),
-            ])),
-        )],
-    };
-    normalize(&mut math);
-    assert_eq!(&math.content[0], &Mi("St+1".to_string()));
+    let contents = std::fs::read_to_string("tests/sir.xml").unwrap();
+    let (_, mut math) = parse(&contents).unwrap();
+    math.normalize();
+    assert_eq!(
+        &math.content[0],
+        &Mrow(vec![
+            Mi("S_{t+1}".to_string()),
+            Mo("=".to_string()),
+            Mi("S_{t}".to_string()),
+            Mo("-".to_string()),
+            Mi("β".to_string()),
+            Mi("S_{t}".to_string()),
+            Mi("I_{t}".to_string()),
+        ])
+    );
 }

--- a/skema/skema-rs/mathml/src/normalization.rs
+++ b/skema/skema-rs/mathml/src/normalization.rs
@@ -1,24 +1,35 @@
-use crate::parsing::parse;
 use crate::ast::{
-    Math,
-    MathExpression,
+    Math, MathExpression,
     MathExpression::{
         Mfrac, Mi, Mn, Mo, MoLine, Mover, Mrow, Mspace, Msqrt, Mstyle, Msub, Msubsup, Msup, Mtext,
         Munder,
     },
 };
-use std::rc::Rc;
-
+use crate::parsing::parse;
 
 impl MathExpression {
-    fn collapse_subscripts(&self) -> Option<MathExpression> {
+    fn collapse_subscripts(&mut self) {
         match self {
             Msub(base, subscript) => {
                 let mut combined = String::from(&base.get_string_repr());
                 combined.push_str(&subscript.get_string_repr());
-                Some(Mi(combined))
+                *self = Mi(combined);
+                //Some(Mi(combined))
             }
-            _ => None
+            //Mn(x) => add_to_graph_0(graph, parent_index, x),
+            //Msqrt(x) => add_to_graph_n!(graph, parent_index, "msqrt", x),
+            //Msup(x1, x2) => add_to_graph_n!(graph, parent_index, "msup", x1, x2),
+            //Msub(x1, x2) => add_to_graph_n!(graph, parent_index, "msub", x1, x2),
+            //Mfrac(x1, x2) => add_to_graph_n!(graph, parent_index, "mfrac", x1, x2),
+            //Mrow(xs) => add_to_graph_many0(graph, parent_index, "mrow", xs),
+            //Munder(xs) => add_to_graph_many0(graph, parent_index, "munder", xs),
+            //Mover(xs) => add_to_graph_many0(graph, parent_index, "mover", xs),
+            //Msubsup(xs) => add_to_graph_many0(graph, parent_index, "msubsup", xs),
+            //Mtext(x) => add_to_graph_0(graph, parent_index, x),
+            //Mstyle(xs) => add_to_graph_many0(graph, parent_index, "mstyle", xs),
+            //Mspace(x) => add_to_graph_0(graph, parent_index, x),
+            //MoLine(x) => add_to_graph_0(graph, parent_index, x),
+            _ => (),
         }
     }
 
@@ -26,23 +37,21 @@ impl MathExpression {
         match self {
             Mi(x) => x.to_string(),
             Mo(x) => x.to_string(),
-            Mrow(xs) => {
-                xs.iter().map(|x| x.get_string_repr()).collect::<Vec<String>>().join("")
-            }
+            Mrow(xs) => xs
+                .iter()
+                .map(|x| x.get_string_repr())
+                .collect::<Vec<String>>()
+                .join(""),
             _ => {
                 panic!("Unhandled type!");
             }
         }
     }
-
 }
 
-fn normalize(math: Math) {
-    for mut expr in math.content {
-        let mut storage = Vec::<String>::new();
-        if let Some(e) = &mut expr.collapse_subscripts() {
-            expr = *e;
-        }
+fn normalize(math: &mut Math) {
+    for expr in &mut math.content {
+        expr.collapse_subscripts();
     }
 }
 
@@ -50,12 +59,38 @@ fn normalize(math: Math) {
 fn test_get_string_repr() {
     assert_eq!(Mi("t".to_string()).get_string_repr(), "t".to_string());
     assert_eq!(Mo("+".to_string()).get_string_repr(), "+".to_string());
-    assert_eq!(Mrow(vec![Mi("t".into()), Mo("+".into()), Mi("1".to_string())]).get_string_repr(), "t+1".to_string());
+    assert_eq!(
+        Mrow(vec![Mi("t".into()), Mo("+".into()), Mi("1".to_string())]).get_string_repr(),
+        "t+1".to_string()
+    );
 }
 
 #[test]
 fn test_subscript_collapsing() {
-    let expr = Msub(Box::new(Mi("S".to_string())), Box::new(Mrow(vec![Mi("t".to_string()), Mo("+".to_string()), Mi("1".to_string())])));
-    let mut storage = Vec::<String>::new();
-    assert_eq!(expr.collapse_subscripts().unwrap(), Mi("St+1".to_string()));
+    let mut expr = Msub(
+        Box::new(Mi("S".to_string())),
+        Box::new(Mrow(vec![
+            Mi("t".to_string()),
+            Mo("+".to_string()),
+            Mi("1".to_string()),
+        ])),
+    );
+    expr.collapse_subscripts();
+    assert_eq!(expr, Mi("St+1".to_string()));
+}
+
+#[test]
+fn test_normalize() {
+    let mut math = Math {
+        content: vec![Msub(
+            Box::new(Mi("S".to_string())),
+            Box::new(Mrow(vec![
+                Mi("t".to_string()),
+                Mo("+".to_string()),
+                Mi("1".to_string()),
+            ])),
+        )],
+    };
+    normalize(&mut math);
+    assert_eq!(&math.content[0], &Mi("St+1".to_string()));
 }

--- a/skema/skema-rs/mathml/src/normalization.rs
+++ b/skema/skema-rs/mathml/src/normalization.rs
@@ -1,11 +1,7 @@
-use crate::parsing::parse;
 use crate::ast::{
     Math, MathExpression,
-    MathExpression::{
-        Mi, Mn, Mo, Mrow, Msub,
-    },
+    MathExpression::{Mi, Mn, Mo, Mrow, Msub},
 };
-
 
 impl MathExpression {
     /// Collapse subscripts
@@ -22,18 +18,6 @@ impl MathExpression {
             Mrow(xs) => {
                 for x in xs {
                     x.collapse_subscripts();
-                }
-            }
-            _ => (),
-        }
-    }
-
-    /// Collapse mrow elements that only have one child element.
-    fn collapse_mrows(&mut self) {
-        match self {
-            Mrow(xs) => {
-                if xs.len() == 1 {
-                    *self = xs[0].clone();
                 }
             }
             _ => (),
@@ -60,11 +44,9 @@ impl MathExpression {
 
 impl Math {
     /// Normalize the math expression, performing the following steps:
-    /// 1. Collapse mrows containing only one child element.
-    /// 2. Collapse subscripts assuming we don't need their substructure.
+    /// 1. Collapse subscripts assuming we don't need their substructure.
     pub fn normalize(&mut self) {
         for expr in &mut self.content {
-            expr.collapse_mrows();
             expr.collapse_subscripts();
         }
     }
@@ -95,6 +77,7 @@ fn test_subscript_collapsing() {
 
 #[test]
 fn test_normalize() {
+    use crate::parsing::parse;
     let contents = std::fs::read_to_string("tests/sir.xml").unwrap();
     let (_, mut math) = parse(&contents).unwrap();
     math.normalize();

--- a/skema/skema-rs/mathml/src/normalization.rs
+++ b/skema/skema-rs/mathml/src/normalization.rs
@@ -1,0 +1,61 @@
+use crate::parsing::parse;
+use crate::ast::{
+    Math,
+    MathExpression,
+    MathExpression::{
+        Mfrac, Mi, Mn, Mo, MoLine, Mover, Mrow, Mspace, Msqrt, Mstyle, Msub, Msubsup, Msup, Mtext,
+        Munder,
+    },
+};
+
+
+impl<'a> MathExpression<'a> {
+    fn collapse_subscripts(&self) -> Option<MathExpression> {
+        match self {
+            Msub(base, subscript) => {
+                let storage = String::new();
+                storage.push_str(&base.get_string_repr());
+                storage.push_str(&subscript.get_string_repr());
+                Some(Mi(storage))
+            }
+            _ => None
+        }
+    }
+
+    fn get_string_repr(&self) -> String {
+        match self {
+            Mi(x) => x.to_string(),
+            Mo(x) => x.to_string(),
+            Mrow(xs) => {
+                xs.iter().map(|x| x.get_string_repr()).collect::<Vec<String>>().join("")
+            }
+            _ => {
+                panic!("Unhandled type!");
+            }
+        }
+    }
+
+}
+
+//fn normalize(math: Math) {
+    //for expr in math.content {
+        //let storage = String::new();
+        //if let Some(e) = expr.collapse_subscripts() {
+            //*expr = e;
+        //}
+    //}
+//}
+
+#[test]
+fn test_get_string_repr() {
+    assert_eq!(Mi("t").get_string_repr(), "t");
+    assert_eq!(Mo("+").get_string_repr(), "+");
+    assert_eq!(Mrow(vec![Mi("t".into()), Mo("+".into()), Mi(&"1")]).get_string_repr(), "t+1");
+}
+
+#[test]
+fn test_subscript_collapsing() {
+    let expr = Msub(Box::new(Mi("S")), Box::new(Mrow(vec![Mi("t"), Mo("+"), Mi("1")])));
+    let mut storage = String::new();
+    assert_eq!(expr.collapse_subscripts().unwrap(), Mi("St+1"));
+}

--- a/skema/skema-rs/mathml/src/normalization.rs
+++ b/skema/skema-rs/mathml/src/normalization.rs
@@ -10,14 +10,13 @@ use crate::ast::{
 use std::rc::Rc;
 
 
-impl<'a> MathExpression<'a> {
-    fn collapse_subscripts(&self, storage: &mut Vec<Rc<String>>) -> Option<MathExpression> {
+impl MathExpression {
+    fn collapse_subscripts(&self) -> Option<MathExpression> {
         match self {
             Msub(base, subscript) => {
-                let mut combined = Rc::new(String::from(&base.get_string_repr()));
+                let mut combined = String::from(&base.get_string_repr());
                 combined.push_str(&subscript.get_string_repr());
-                storage.push(Rc::clone(&combined));
-                Some(Mi(&combined))
+                Some(Mi(combined))
             }
             _ => None
         }
@@ -40,8 +39,8 @@ impl<'a> MathExpression<'a> {
 
 fn normalize(math: Math) {
     for mut expr in math.content {
-        let mut storage = Vec::<Rc<String>>::new();
-        if let Some(e) = &mut expr.collapse_subscripts(&mut storage) {
+        let mut storage = Vec::<String>::new();
+        if let Some(e) = &mut expr.collapse_subscripts() {
             expr = *e;
         }
     }
@@ -49,14 +48,14 @@ fn normalize(math: Math) {
 
 #[test]
 fn test_get_string_repr() {
-    assert_eq!(Mi("t").get_string_repr(), "t");
-    assert_eq!(Mo("+").get_string_repr(), "+");
-    assert_eq!(Mrow(vec![Mi("t".into()), Mo("+".into()), Mi("1")]).get_string_repr(), "t+1");
+    assert_eq!(Mi("t".to_string()).get_string_repr(), "t".to_string());
+    assert_eq!(Mo("+".to_string()).get_string_repr(), "+".to_string());
+    assert_eq!(Mrow(vec![Mi("t".into()), Mo("+".into()), Mi("1".to_string())]).get_string_repr(), "t+1".to_string());
 }
 
 #[test]
 fn test_subscript_collapsing() {
-    let expr = Msub(Box::new(Mi("S")), Box::new(Mrow(vec![Mi("t"), Mo("+"), Mi("1")])));
-    let mut storage = Vec::<Rc<String>>::new();
-    assert_eq!(expr.collapse_subscripts(&mut storage).unwrap(), Mi("St+1"));
+    let expr = Msub(Box::new(Mi("S".to_string())), Box::new(Mrow(vec![Mi("t".to_string()), Mo("+".to_string()), Mi("1".to_string())])));
+    let mut storage = Vec::<String>::new();
+    assert_eq!(expr.collapse_subscripts().unwrap(), Mi("St+1".to_string()));
 }

--- a/skema/skema-rs/mathml/src/normalization.rs
+++ b/skema/skema-rs/mathml/src/normalization.rs
@@ -36,7 +36,7 @@ impl MathExpression {
                 .collect::<Vec<String>>()
                 .join(""),
             _ => {
-                panic!("Unhandled type!");
+                panic!("The method 'get_string_repr' for the MathExpression enum only handles the following MathML element types: [mi, mo, mn, mrow]!");
             }
         }
     }

--- a/skema/skema-rs/mathml/src/parsing.rs
+++ b/skema/skema-rs/mathml/src/parsing.rs
@@ -141,19 +141,19 @@ macro_rules! elem_many0 {
 /// Identifiers
 fn mi(input: Span) -> IResult<MathExpression> {
     let (s, element) = elem0!("mi")(input)?;
-    Ok((s, Mi(&element)))
+    Ok((s, Mi(element.to_string())))
 }
 
 /// Numbers
 fn mn(input: Span) -> IResult<MathExpression> {
     let (s, element) = elem0!("mn")(input)?;
-    Ok((s, Mn(&element)))
+    Ok((s, Mn(element.to_string())))
 }
 
 /// Operators
 fn mo(input: Span) -> IResult<MathExpression> {
     let (s, element) = elem0!("mo")(input)?;
-    Ok((s, Mo(&element)))
+    Ok((s, Mo(element.to_string())))
 }
 
 /// Rows
@@ -207,7 +207,7 @@ fn msubsup(input: Span) -> IResult<MathExpression> {
 //Text
 fn mtext(input: Span) -> IResult<MathExpression> {
     let (s, element) = elem0!("mtext")(input)?;
-    Ok((s, Mtext(&element)))
+    Ok((s, Mtext(element.to_string())))
 }
 
 //mstyle
@@ -225,13 +225,13 @@ fn xml_declaration(input: Span) -> IResult<()> {
 //mspace
 fn mspace(input: Span) -> IResult<MathExpression> {
     let (s, element) = ws(delimited(tag("<mspace"), take_until("/>"), tag("/>")))(input)?;
-    Ok((s, Mspace(&element)))
+    Ok((s, Mspace(element.to_string())))
 }
 
 // Some xml have <mo .../>
 fn mo_line(input: Span) -> IResult<MathExpression> {
     let (s, element) = ws(delimited(tag("<mo"), take_until("/>"), tag("/>")))(input)?;
-    Ok((s, MoLine(&element)))
+    Ok((s, MoLine(element.to_string())))
 }
 
 /// Math expressions
@@ -268,17 +268,17 @@ where
 
 #[test]
 fn test_mi() {
-    test_parser("<mi k=\"v\" m1=\"n\">x</mi>", mi, Mi("x"))
+    test_parser("<mi k=\"v\" m1=\"n\">x</mi>", mi, Mi("x".to_string()))
 }
 
 #[test]
 fn test_mo() {
-    test_parser("<mo>=</mo>", mo, Mo("="))
+    test_parser("<mo>=</mo>", mo, Mo("=".to_string()))
 }
 
 #[test]
 fn test_mn() {
-    test_parser("<mn>1</mn>", mn, Mn("1"));
+    test_parser("<mn>1</mn>", mn, Mn("1".to_string()));
 }
 
 #[test]
@@ -286,7 +286,7 @@ fn test_mrow() {
     test_parser(
         "<mrow><mo>-</mo><mi>b</mi></mrow>",
         mrow,
-        Mrow(vec![Mo("-"), Mi("b")]),
+        Mrow(vec![Mo("-".to_string()), Mi("b".to_string())]),
     )
 }
 
@@ -300,7 +300,7 @@ fn test_mfrac() {
     let frac = mfrac(Span::new("<mfrac><mn>1</mn><mn>2</mn></mfrac>"))
         .unwrap()
         .1;
-    assert_eq!(frac, Mfrac(Box::new(Mn("1")), Box::new(Mn("2"))),)
+    assert_eq!(frac, Mfrac(Box::new(Mn("1".to_string())), Box::new(Mn("2".to_string()))),)
 }
 
 #[test]
@@ -308,7 +308,7 @@ fn test_math_expression() {
     test_parser(
         "<mrow><mo>-</mo><mi>b</mi></mrow>",
         math_expression,
-        Mrow(vec![Mo("-"), Mi("b")]),
+        Mrow(vec![Mo("-".to_string()), Mi("b".to_string())]),
     )
 }
 
@@ -317,7 +317,7 @@ fn test_mover() {
     test_parser(
         "<mover><mi>x</mi><mo>¯</mo></mover>",
         mover,
-        Mover(vec![Mi("x"), Mo("¯")]),
+        Mover(vec![Mi("x".to_string()), Mo("¯".to_string())]),
     )
 }
 
@@ -326,7 +326,7 @@ fn test_munder() {
     test_parser(
         "<munder><mo>inf</mo><mn>0</mn><mo>≤</mo><mi>t</mi><mo>≤</mo></munder>",
         munder,
-        Munder(vec![Mo("inf"), Mn("0"), Mo("≤"), Mi("t"), Mo("≤")]),
+        Munder(vec![Mo("inf".to_string()), Mn("0".to_string()), Mo("≤".to_string()), Mi("t".to_string()), Mo("≤".to_string())]),
     )
 }
 
@@ -335,13 +335,13 @@ fn test_msubsup() {
     test_parser(
         "<msubsup><mi>L</mi><mi>t</mi><mi>∞</mi></msubsup>",
         msubsup,
-        Msubsup(vec![Mi("L"), Mi("t"), Mi("∞")]),
+        Msubsup(vec![Mi("L".to_string()), Mi("t".to_string()), Mi("∞".to_string())]),
     )
 }
 
 #[test]
 fn test_mtext() {
-    test_parser("<mtext>if</mtext>", mtext, Mtext("if"));
+    test_parser("<mtext>if</mtext>", mtext, Mtext("if".to_string()));
 }
 
 #[test]
@@ -349,13 +349,13 @@ fn test_mstyle() {
     test_parser(
         "<mstyle><mo>∑</mo><mi>I</mi></mstyle>",
         mstyle,
-        Mstyle(vec![Mo("∑"), Mi("I")]),
+        Mstyle(vec![Mo("∑".to_string()), Mi("I".to_string())]),
     )
 }
 
 #[test]
 fn test_mspace() {
-    test_parser("<mspace width=\"1em\"/>", mspace, Mspace(" width=\"1em\""));
+    test_parser("<mspace width=\"1em\"/>", mspace, Mspace(" width=\"1em\"".to_string()));
 }
 
 #[test]
@@ -363,7 +363,7 @@ fn test_moline() {
     test_parser(
         "<mo fence=\"true\" stretchy=\"true\" symmetric=\"true\"/>",
         mo_line,
-        MoLine(" fence=\"true\" stretchy=\"true\" symmetric=\"true\""),
+        MoLine(" fence=\"true\" stretchy=\"true\" symmetric=\"true\"".to_string()),
     );
 }
 
@@ -378,48 +378,48 @@ fn test_math() {
             </math>",
         math,
         Math {
-            content: vec![Mrow(vec![Mo("-"), Mi("b")])],
+            content: vec![Mrow(vec![Mo("-".to_string()), Mi("b".to_string())])],
         },
     )
 }
 
 #[test]
 fn test_mathml_parser() {
-    let eqn = std::fs::read_to_string("tests/test01.xml").unwrap();
+    let eqn = std::fs::read_to_string("tests/test01.xml".to_string()).unwrap();
     test_parser(
         &eqn,
         math,
         Math {
             content: vec![
                 Munder(vec![
-                    Mo("sup"),
+                    Mo("sup".to_string()),
                     Mrow(vec![
-                        Mn("0"),
-                        Mo("≤"),
-                        Mi("t"),
-                        Mo("≤"),
-                        Msub(Box::new(Mi("T")), Box::new(Mn("0"))),
+                        Mn("0".to_string()),
+                        Mo("≤".to_string()),
+                        Mi("t".to_string()),
+                        Mo("≤".to_string()),
+                        Msub(Box::new(Mi("T".to_string())), Box::new(Mn("0".to_string()))),
                     ]),
                 ]),
-                Mo("‖"),
+                Mo("‖".to_string()),
                 Msup(
-                    Box::new(Mrow(vec![Mover(vec![Mi("ρ"), Mo("~")])])),
-                    Box::new(Mi("R")),
+                    Box::new(Mrow(vec![Mover(vec![Mi("ρ".to_string()), Mo("~".to_string())])])),
+                    Box::new(Mi("R".to_string())),
                 ),
                 Msup(
-                    Box::new(Mrow(vec![Mover(vec![Mi("x"), Mo("¯")])])),
-                    Box::new(Mi("a")),
+                    Box::new(Mrow(vec![Mover(vec![Mi("x".to_string()), Mo("¯".to_string())])])),
+                    Box::new(Mi("a".to_string())),
                 ),
                 Msub(
-                    Box::new(Mo("‖")),
+                    Box::new(Mo("‖".to_string())),
                     Box::new(Mrow(vec![
-                        Msup(Box::new(Mi("L")), Box::new(Mn("1"))),
-                        Mo("∩"),
-                        Msup(Box::new(Mi("L")), Box::new(Mi("∞"))),
+                        Msup(Box::new(Mi("L".to_string())), Box::new(Mn("1".to_string()))),
+                        Mo("∩".to_string()),
+                        Msup(Box::new(Mi("L".to_string())), Box::new(Mi("∞".to_string()))),
                     ])),
                 ),
-                Mo("≤"),
-                Mi("C"),
+                Mo("≤".to_string()),
+                Mi("C".to_string()),
             ],
         },
     )

--- a/skema/skema-rs/mathml/src/parsing.rs
+++ b/skema/skema-rs/mathml/src/parsing.rs
@@ -300,7 +300,10 @@ fn test_mfrac() {
     let frac = mfrac(Span::new("<mfrac><mn>1</mn><mn>2</mn></mfrac>"))
         .unwrap()
         .1;
-    assert_eq!(frac, Mfrac(Box::new(Mn("1".to_string())), Box::new(Mn("2".to_string()))),)
+    assert_eq!(
+        frac,
+        Mfrac(Box::new(Mn("1".to_string())), Box::new(Mn("2".to_string()))),
+    )
 }
 
 #[test]
@@ -326,7 +329,13 @@ fn test_munder() {
     test_parser(
         "<munder><mo>inf</mo><mn>0</mn><mo>≤</mo><mi>t</mi><mo>≤</mo></munder>",
         munder,
-        Munder(vec![Mo("inf".to_string()), Mn("0".to_string()), Mo("≤".to_string()), Mi("t".to_string()), Mo("≤".to_string())]),
+        Munder(vec![
+            Mo("inf".to_string()),
+            Mn("0".to_string()),
+            Mo("≤".to_string()),
+            Mi("t".to_string()),
+            Mo("≤".to_string()),
+        ]),
     )
 }
 
@@ -335,7 +344,11 @@ fn test_msubsup() {
     test_parser(
         "<msubsup><mi>L</mi><mi>t</mi><mi>∞</mi></msubsup>",
         msubsup,
-        Msubsup(vec![Mi("L".to_string()), Mi("t".to_string()), Mi("∞".to_string())]),
+        Msubsup(vec![
+            Mi("L".to_string()),
+            Mi("t".to_string()),
+            Mi("∞".to_string()),
+        ]),
     )
 }
 
@@ -355,7 +368,11 @@ fn test_mstyle() {
 
 #[test]
 fn test_mspace() {
-    test_parser("<mspace width=\"1em\"/>", mspace, Mspace(" width=\"1em\"".to_string()));
+    test_parser(
+        "<mspace width=\"1em\"/>",
+        mspace,
+        Mspace(" width=\"1em\"".to_string()),
+    );
 }
 
 #[test]
@@ -385,7 +402,7 @@ fn test_math() {
 
 #[test]
 fn test_mathml_parser() {
-    let eqn = std::fs::read_to_string("tests/test01.xml".to_string()).unwrap();
+    let eqn = std::fs::read_to_string("tests/test01.xml").unwrap();
     test_parser(
         &eqn,
         math,
@@ -403,11 +420,17 @@ fn test_mathml_parser() {
                 ]),
                 Mo("‖".to_string()),
                 Msup(
-                    Box::new(Mrow(vec![Mover(vec![Mi("ρ".to_string()), Mo("~".to_string())])])),
+                    Box::new(Mrow(vec![Mover(vec![
+                        Mi("ρ".to_string()),
+                        Mo("~".to_string()),
+                    ])])),
                     Box::new(Mi("R".to_string())),
                 ),
                 Msup(
-                    Box::new(Mrow(vec![Mover(vec![Mi("x".to_string()), Mo("¯".to_string())])])),
+                    Box::new(Mrow(vec![Mover(vec![
+                        Mi("x".to_string()),
+                        Mo("¯".to_string()),
+                    ])])),
                     Box::new(Mi("a".to_string())),
                 ),
                 Msub(


### PR DESCRIPTION
This PR implements collapsing subscripts in presentation MathML documents. To get this to work, a number of other refactoring steps were needed, the most significant of which is to convert the arguments of the enum variants in `MathExpression` from `&'a str` to `String` in order to have them own the data themselves rather than just pointers to it. This makes traversal and in-place modification much easier, at the cost of introducing `.to_string()` method calls in the test functions.

Unnormalized presentation MathML expression:

![original_sir](https://user-images.githubusercontent.com/653549/200692198-1a691a04-2ca2-4922-95ef-f9ff8700a920.png)


Normalized expression:
![sir_collapsed_subscripts](https://user-images.githubusercontent.com/653549/200692265-d2ed6092-bda2-4f19-a2ff-5a0e6809c3cc.png)

The implementation is a minimal, proof of concept one, so it may not be able to handle more complicated expressions, but at least it works with the CHIME SIR update equation.
