### PR TITLE
Show how to use Pdf2Txt

### DIFF
--- a/skema/text_reading/text_reading/build.sbt
+++ b/skema/text_reading/text_reading/build.sbt
@@ -13,6 +13,7 @@ libraryDependencies ++= {
   val uJsonVer = "2.0.0"
 
   Seq(
+    "org.clulab"                 %% "pdf2txt"            % "1.1.3",
     "org.clulab"                 %% "processors-main"    % procVer,
     "org.clulab"                 %% "processors-corenlp" % procVer,
     "ai.lum"                     %% "common"             % "0.0.10",
@@ -24,7 +25,7 @@ libraryDependencies ++= {
     "com.lihaoyi"                %% "requests"           % "0.7.1",
     "com.typesafe.play"          %% "play-json"          % "2.9.3",
     "org.scala-lang.modules"     %% "scala-xml"          % "1.0.6", // 2.1.0",
-    "org.clulab"                 %  "glove-840b-300d"    % "0.1.0" % Test,
+    "org.clulab"                  % "glove-840b-300d"    % "0.1.0" % Test,
     "org.scalatest"              %% "scalatest"          % "3.0.9" % Test
   )
 }

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/apps/Pdf2TxtApp.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/apps/Pdf2TxtApp.scala
@@ -1,0 +1,46 @@
+package org.ml4ai.skema.text_reading.apps
+
+import org.clulab.pdf2txt.Pdf2txt
+import org.clulab.pdf2txt.common.pdf.TextConverter
+import org.clulab.pdf2txt.languageModel.GigawordLanguageModel
+import org.clulab.pdf2txt.preprocessor.{CasePreprocessor, LigaturePreprocessor, LineBreakPreprocessor, LinePreprocessor, NumberPreprocessor, ParagraphPreprocessor, UnicodePreprocessor, WordBreakByHyphenPreprocessor, WordBreakBySpacePreprocessor}
+
+object Pdf2TxtApp extends App {
+  val pdfConverter = new TextConverter()
+  val languageModel = GigawordLanguageModel()
+  val preprocessors = Array(
+    new LinePreprocessor(),
+    new ParagraphPreprocessor(),
+    new UnicodePreprocessor(),
+    new CasePreprocessor(CasePreprocessor.defaultCutoff),
+    new NumberPreprocessor(NumberPreprocessor.Hyperparameters()),
+    new LigaturePreprocessor(languageModel),
+    new LineBreakPreprocessor(languageModel),
+    new WordBreakByHyphenPreprocessor(),
+    new WordBreakBySpacePreprocessor(languageModel) // This is by default NeverLanguageModel.
+  )
+  val pdf2txt = new Pdf2txt(pdfConverter, preprocessors)
+  val rawTexts = Array(
+    "fi gures",
+    "o ffi cials",
+    "di ffi cult",
+    "sta ffi ng",
+    "shif ts",
+    "speci fi cally",
+    "ca not",
+    "we ' ve",
+    "tra ffi c",
+    "fi rst",
+    "Here 's",
+    "Let 's",
+    "hospital s"
+  )
+
+  rawTexts.foreach { rawText =>
+    val cookedText = pdf2txt.process(rawText, maxLoops = 1)
+
+    println(s"   rawText: $rawText")
+    println(s"cookedText: $cookedText")
+    println()
+  }
+}


### PR DESCRIPTION
Output is

```
   rawText: fi gures
cookedText: figures .

   rawText: o ffi cials
cookedText: officials .

   rawText: di ffi cult
cookedText: difficult.

   rawText: sta ffi ng
cookedText: staffing .

   rawText: shif ts
cookedText: shifts .

   rawText: speci fi cally
cookedText: specifically .

   rawText: ca not
cookedText: canot .

   rawText: we ' ve
cookedText: we 've .

   rawText: tra ffi c
cookedText: traffic .

   rawText: fi rst
cookedText: first .

   rawText: Here 's
cookedText: Here 's.

   rawText: Let 's
cookedText: Let 's.

   rawText: hospital s
cookedText: hospitals .
```

The apostrophes are not corrected and they might need a special case.  hospitals and shifts are corrected by the WordBreakBySpacePreprocessor, which is not normally used.  It often overcorrects, as it does here for canot.  I'm not sure that `shif ts` is a normal ligature problem.  Usually the f and t would be together, but it could be added to the list.  It would probably be better to have the mistakes accompanied by their contexts.