### PR TITLE
Updating code2fn client.py to properly write output JSON to file

### DIFF
--- a/skema/code2fn/client.py
+++ b/skema/code2fn/client.py
@@ -46,4 +46,5 @@ url = f"http://{args.host}:{args.port}"
 data = system_to_json(args.root_path, args.system_filepaths, args.system_name)
 response = requests.post(url, data=data)
 
-print(data)
+with open(f"{args.system_name}--Gromet-FN-auto.json", "w") as f:
+    f.write(response.json())


### PR DESCRIPTION
The current version of the example code2fn client program `client.py` is slightly outdated and has an issue where the request JSON is being output to the console instead of the response JSON being written to file.

 This pull request updates the client so that the response JSON is now written to a file with the naming convention: `{args.system_name}--Gromet-FN-auto.json`