### PR TITLE
Code2FN updates

### DIFF
--- a/skema/code2fn/client.py
+++ b/skema/code2fn/client.py
@@ -38,16 +38,11 @@ def system_to_json(
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--host",
-        default="localhost",
+        "--url",
+        default="http://localhost:8000/fn-given-filepaths",
         help="Host machine where the Code2FN service is running",
     )
-    parser.add_argument(
-        "--port",
-        type=int,
-        default=8000,
-        help="Port on which the Code2FN service is running",
-    )
+
     parser.add_argument(
         "--write",
         action="store_true",
@@ -63,11 +58,10 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    url = f"http://{args.host}:{args.port}"
     data = system_to_json(
         args.root_path, args.system_filepaths, args.system_name
     )
-    response = requests.post(url, data=data)
+    response = requests.post(args.url, data=data)
 
     if args.write:
         with open(f"{args.system_name}--Gromet-FN-auto.json", "w") as f:

--- a/skema/code2fn/server.py
+++ b/skema/code2fn/server.py
@@ -19,7 +19,18 @@ class System(BaseModel):
 app = FastAPI()
 
 
-@app.post("/")
+@app.ping("/ping", summary="Ping endpoint to test health of service")
+def ping():
+    return "The Code2FN service is running."
+
+
+@app.post(
+    "/fn-given-filepaths",
+    summary=(
+        "Send a system of code and filepaths of interest,"
+        " get a GroMEt FN Module collection back."
+    ),
+)
 async def root(system: System):
     # Create a tempory directory to store module
     with tempfile.TemporaryDirectory() as tmp:

--- a/skema/code2fn/server.py
+++ b/skema/code2fn/server.py
@@ -19,7 +19,7 @@ class System(BaseModel):
 app = FastAPI()
 
 
-@app.ping("/ping", summary="Ping endpoint to test health of service")
+@app.get("/ping", summary="Ping endpoint to test health of service")
 def ping():
     return "The Code2FN service is running."
 


### PR DESCRIPTION
This PR updates the Code2FN service and example client.

- Instead of providing separate host and port arguments, we just use a URL argument in client.py
- Adds a ping endpoint for testing the health of the service
- changes the main endpoint from `/` to `/fn-given-filepaths`