### PR TITLE
Assemble for text reading

### DIFF
--- a/skema/text_reading/text_reading/assembly.sbt
+++ b/skema/text_reading/text_reading/assembly.sbt
@@ -1,0 +1,20 @@
+assembly / aggregate := false
+assembly / assemblyMergeStrategy := {
+  case PathList("CHANGES.md")                              => MergeStrategy.discard
+  case PathList("com", "sun", "istack", _*)                => MergeStrategy.first
+  case PathList("com", "sun", "xml", _*)                   => MergeStrategy.first
+  case PathList("javax", "activation", _*)                 => MergeStrategy.first
+  case PathList("javax", "xml", "bind", _*)                => MergeStrategy.first
+  case PathList("logback.xml")                             => MergeStrategy.last
+  case PathList("META-INF", "versions", _*)                => MergeStrategy.first
+  case PathList("module-info.class")                       => MergeStrategy.discard 
+  case PathList("org", "apache", "commons", "logging", _*) => MergeStrategy.first
+  case PathList("org", "bouncycastle", _*)                 => MergeStrategy.first
+  // Otherwise just keep one copy if the contents are the same and complain if not.
+  case other => // MergeStrategy.deduplicate
+    val oldStrategy = (assembly / assemblyMergeStrategy).value
+    oldStrategy(other)
+}
+// This prevents testing in root, then non-aggregation prevents it in other subprojects.
+assembly / mainClass := None
+assembly / test := {}

--- a/skema/text_reading/text_reading/build.sbt
+++ b/skema/text_reading/text_reading/build.sbt
@@ -8,29 +8,28 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= {
+  val breezeVer = "1.2"
   val procVer = "8.5.3"
   val uJsonVer = "2.0.0"
 
   Seq(
+    "org.scalanlp"               %% "breeze"             % breezeVer,
+    "org.scalanlp"               %% "breeze-natives"     % breezeVer,
+    "org.scalanlp"               %% "breeze-viz"         % breezeVer,
+    "ai.lum"                     %% "common"             % "0.0.10",
+    "org.clulab"                  % "glove-840b-300d"    % "0.1.0" % Test,
     "org.clulab"                 %% "pdf2txt"            % "1.1.3",
+    "com.typesafe.play"          %% "play-json"          % "2.9.3",
     "org.clulab"                 %% "processors-main"    % procVer,
     "org.clulab"                 %% "processors-corenlp" % procVer,
-    "xml-apis"                    % "xml-apis"           % "1.4.01",
-    "ai.lum"                     %% "common"             % "0.0.10",
+    "com.lihaoyi"                %% "requests"           % "0.7.1",
+    "org.scala-lang.modules"     %% "scala-xml"          % "1.0.6",
+    "org.scalatest"              %% "scalatest"          % "3.0.9" % Test,
     "com.lihaoyi"                %% "ujson"              % uJsonVer,
     "com.lihaoyi"                %% "upickle"            % uJsonVer,
     "com.lihaoyi"                %% "ujson-json4s"       % uJsonVer,
     "com.lihaoyi"                %% "ujson-play"         % uJsonVer,
-    "com.lihaoyi"                %% "requests"           % "0.7.1",
-    "com.typesafe.play"          %% "play-json"          % "2.9.3",
-    "org.scala-lang.modules"     %% "scala-xml"          % "1.0.6", // 2.1.0",
-    "org.clulab"                  % "glove-840b-300d"    % "0.1.0" % Test,
-    "org.scalatest"              %% "scalatest"          % "3.0.9" % Test,
-    "org.clulab"                 %  "glove-840b-300d"    % "0.1.0" % Test,
-    "org.scalatest"              %% "scalatest"          % "3.0.9" % Test,
-    "org.scalanlp" %% "breeze" % "1.1",
-    "org.scalanlp" %% "breeze-natives" % "1.1",
-    "org.scalanlp" %% "breeze-viz" % "1.1",
+    "xml-apis"                    % "xml-apis"           % "1.4.01"
   )
 }
 


### PR DESCRIPTION
This addition *should* make it possible to produce a fat jar file.  We need to fill in the `mainClass` at the very least.  It should be tested, even if unit tests are passing.  Sometimes people have tried to access files that are no longer available outside the development environment and it only shows up now.  Plus I might not have merged some of files incorrectly.  Also, it might be good not to compress the large resource files as they are added to the jar.  It takes a long time and then they need to be repeatedly decompressed each time the program runs, slowing startup time.  I can add that later after everything is known to work.