### PR TITLE
Fix bug where CWD is lost

### DIFF
--- a/skema/program_analysis/python2cast.py
+++ b/skema/program_analysis/python2cast.py
@@ -100,20 +100,22 @@ def python_to_cast(
     # 'Root' the current working directory so that it's where the
     # Source file we're generating CAST for is (for Import statements)
     old_path = os.getcwd()
-    idx = pyfile_path.rfind("/")
+    try:
+        idx = pyfile_path.rfind("/")
 
-    if idx > -1:
-        curr_path = pyfile_path[0:idx]
-        os.chdir(curr_path)
-    else:
-        curr_path = "./" + pyfile_path
+        if idx > -1:
+            curr_path = pyfile_path[0:idx]
+            os.chdir(curr_path)
+        else:
+            curr_path = "./" + pyfile_path
 
-    # Parse the Python program's AST and create the CAST
-    contents = ast.parse(file_contents)
-    C = convert.visit(contents, {}, {})
-    C.source_refs = [SourceRef(file_name, None, None, 1, line_count)]
+        # Parse the Python program's AST and create the CAST
+        contents = ast.parse(file_contents)
+        C = convert.visit(contents, {}, {})
+        C.source_refs = [SourceRef(file_name, None, None, 1, line_count)]
+    finally:
+        os.chdir(old_path)
 
-    os.chdir(old_path)
     out_cast = cast.CAST([C], "python")
 
     if agraph:

--- a/skema/program_analysis/script_functions.py
+++ b/skema/program_analysis/script_functions.py
@@ -157,22 +157,24 @@ def python_to_cast(
     # 'Root' the current working directory so that it's where the
     # Source file we're generating CAST for is (for Import statements)
     old_path = os.getcwd()
-    idx = pyfile_path.rfind("/")
+    try:
+        idx = pyfile_path.rfind("/")
 
-    if idx > -1:
-        curr_path = pyfile_path[0:idx]
-        os.chdir(curr_path)
-    else:
-        curr_path = "./" + pyfile_path
+        if idx > -1:
+            curr_path = pyfile_path[0:idx]
+            os.chdir(curr_path)
+        else:
+            curr_path = "./" + pyfile_path
 
-    # os.chdir(curr_path)
+        # os.chdir(curr_path)
 
-    # Parse the python program's AST and create the CAST
-    contents = ast.parse(file_contents)
-    C = convert.visit(contents, {}, {})
-    C.source_refs = [SourceRef(file_name, None, None, 1, line_count)]
+        # Parse the python program's AST and create the CAST
+        contents = ast.parse(file_contents)
+        C = convert.visit(contents, {}, {})
+        C.source_refs = [SourceRef(file_name, None, None, 1, line_count)]
+    finally:
+        os.chdir(old_path)
 
-    os.chdir(old_path)
     out_cast = cast.CAST([C], "python")
 
     if agraph:

--- a/skema/utils/script_functions.py
+++ b/skema/utils/script_functions.py
@@ -156,22 +156,24 @@ def python_to_cast(
     # 'Root' the current working directory so that it's where the
     # Source file we're generating CAST for is (for Import statements)
     old_path = os.getcwd()
-    idx = pyfile_path.rfind("/")
+    try:
+        idx = pyfile_path.rfind("/")
 
-    if idx > -1:
-        curr_path = pyfile_path[0:idx]
-        os.chdir(curr_path)
-    else:
-        curr_path = "./" + pyfile_path
+        if idx > -1:
+            curr_path = pyfile_path[0:idx]
+            os.chdir(curr_path)
+        else:
+            curr_path = "./" + pyfile_path
 
-    # os.chdir(curr_path)
+        # os.chdir(curr_path)
 
-    # Parse the python program's AST and create the CAST
-    contents = ast.parse(file_contents)
-    C = convert.visit(contents, {}, {})
-    C.source_refs = [SourceRef(file_name, None, None, 1, line_count)]
+        # Parse the python program's AST and create the CAST
+        contents = ast.parse(file_contents)
+        C = convert.visit(contents, {}, {})
+        C.source_refs = [SourceRef(file_name, None, None, 1, line_count)]
+    finally:
+        os.chdir(old_path)
 
-    os.chdir(old_path)
     out_cast = cast.CAST([C], "python")
 
     if agraph:


### PR DESCRIPTION
If code that is unable to be parsed by the AST library is submitted, the program can end up in a state such that the current directory does not exist, causing further evocations to fail.

This should ensure that we always return to the original directory regardless of failure.