### PR TITLE
Scenario Context

### DIFF
--- a/skema/text_reading/text_reading/src/main/resources/org/ml4ai/skema/text_reading/grammars/locations.yml
+++ b/skema/text_reading/text_reading/src/main/resources/org/ml4ai/skema/text_reading/grammars/locations.yml
@@ -8,7 +8,7 @@ rules:
     type: token
     example: "These crises include the 2015 - 2016 civil war in Burundi and the 2013 - 2016 conflict in the Central African Republic ( CAR )"
     pattern: |
-      [entity = "LOCATION"]+
+      [entity = /${locationContext}/]+
 
 
   - name: entity-location-appos

--- a/skema/text_reading/text_reading/src/main/resources/org/ml4ai/skema/text_reading/grammars/vars.yml
+++ b/skema/text_reading/text_reading/src/main/resources/org/ml4ai/skema/text_reading/grammars/vars.yml
@@ -49,3 +49,8 @@ PP+NP: "[chunk = /B-PP/] [chunk = /I-NP|B-NP/ & !tag = /-LRB-|-RRB-|WDT/]+"
 ### AVOIDS LIST FOR MODEL NAMES ###
 
 modelAvoids: "CSV|COVID|SARS|OECD|DOI"
+
+# Scenario Context entity types
+# Location context
+
+locationContext: "CITY|COUNTRY|LOCATION|ORGANIZATION|STATE_OR_PROVINCE"

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/CosmosTextReadingPipeline.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/CosmosTextReadingPipeline.scala
@@ -1,107 +1,18 @@
 package org.ml4ai.skema.text_reading
 
-import ai.lum.common.ConfigUtils._
-import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
-import org.clulab.odin.{EventMention, Mention, RelationMention, TextBoundMention}
+import org.clulab.odin.Mention
 import org.clulab.pdf2txt.Pdf2txt
 import org.clulab.pdf2txt.common.pdf.TextConverter
 import org.clulab.pdf2txt.languageModel.GigawordLanguageModel
 import org.clulab.pdf2txt.preprocessor._
-import org.clulab.processors.Document
-import org.clulab.utils.Logging
-import org.ml4ai.grounding.{GroundingCandidate, MiraEmbeddingsGrounder}
-import org.ml4ai.skema.text_reading.attachments.{GroundingAttachment, MentionLocationAttachment}
+import org.ml4ai.skema.text_reading.attachments.MentionLocationAttachment
 import org.ml4ai.skema.text_reading.data.CosmosJsonDataLoader
+import org.ml4ai.skema.text_reading.scenario_context.{ContextEngine, CosmosOrderer, SentenceIndexOrderer}
 import org.ml4ai.skema.text_reading.serializer.AutomatesJSONSerializer
 
-import scala.util.matching.Regex
 import scala.collection.mutable.ArrayBuffer
 
-class TextReadingPipeline extends Logging {
-  logger.info("Initializing the OdinEngine ...")
 
-  // Read the configuration from the files
-  val generalConfig: Config = ConfigFactory.load()
-  val readerType: String = generalConfig[String]("ReaderType")
-  val defaultConfig: Config = generalConfig[Config](readerType)
-  val config: Config = defaultConfig.withValue("preprocessorType", ConfigValueFactory.fromAnyRef("PassThrough"))
-  val groundingConfig: Config = generalConfig.getConfig("Grounding")
-
-  // Grounding parameters
-  private val ontologyFilePath = groundingConfig.getString("ontologyPath")
-  private val groundingAssignmentThreshold = groundingConfig.getDouble("assignmentThreshold")
-  private val grounder = MiraEmbeddingsGrounder(ontologyFilePath, None, lambda = 10, alpha = 1.0f) // TODO: Fix this @Enrique
-
-  val numberPattern: Regex = """^\.?(\d)+([.,]?\d*)*$""".r
-
-  // Odin Engine instantiation
-  private val odinEngine = OdinEngine.fromConfig(config)
-  // Initialize the odin engine
-  odinEngine.annotate("x = 10")
-
-  /**
-    * Assigns grounding elements to a mention
-    *
-    * @param m mention to ground
-    * @return instance of the mention with grounding attachment if applicable
-    */
-  def groundMention(m: Mention): Mention = m match {
-    case tbm: TextBoundMention =>
-      val isGrounded =
-        tbm.attachments.exists(!_.isInstanceOf[GroundingAttachment])
-
-      if (!isGrounded) {
-        // Don't ground unless it is not a number
-        numberPattern.findFirstIn(tbm.text.trim) match {
-          case None =>
-            val topGroundingCandidates = grounder.groundingCandidates(tbm.text).filter {
-              case GroundingCandidate(_, score) => score >= groundingAssignmentThreshold
-            }
-
-            if (topGroundingCandidates.nonEmpty)
-              tbm.withAttachment(new GroundingAttachment(topGroundingCandidates))
-            else
-              tbm
-          case Some(_) => tbm // If it is a number, then don't ground
-        }
-
-      }
-      else
-        tbm
-    case e: EventMention =>
-      val groundedArguments =
-        e.arguments.mapValues(_.map(groundMention))
-
-
-      e.copy(arguments = groundedArguments)
-    // This is duplicated while we fix the Mention trait to define the abstract method copy
-    case e: RelationMention =>
-      val groundedArguments =
-        e.arguments.mapValues(_.map(groundMention))
-
-      e.copy(arguments = groundedArguments)
-    case m => m
-  }
-
-  /**
-    * Runs the mention extraction engine on the  parameter
-    * @param text to annotate
-    * @param fileName to identify the provenance of the document being annotated
-    * @return Annotated doc object and the mentions extracted by odin
-    */
-  def extractMentions(text:String, fileName: Option[String]): (Document, Seq[Mention]) = {
-    // Extract mentions and apply grounding
-    val (doc, mentions) = odinEngine.extractFromText(text, keepText = true, fileName)
-    // Run grounding
-    val groundedMentions =  mentions.par.map {
-      // Only ground arguments of events and relations, to save time
-      case e@(_: EventMention | _: RelationMention) => groundMention(e)
-      case m => m
-    }.seq
-
-    (doc, groundedMentions)
-  }
-}
 
 class CosmosTextReadingPipeline extends TextReadingPipeline {
 
@@ -137,7 +48,7 @@ class CosmosTextReadingPipeline extends TextReadingPipeline {
     */
   def extractMentionsFromCosmosJson(jsonPath: String): Seq[Mention] = {
 
-    // TODO: Make this interpretable
+    //TODO: Make this interpretable
     val textsAndLocations = loader.loadFile(jsonPath)
     val textsAndFilenames = textsAndLocations.map(_.split(jsonSeparator).slice(0, 2).mkString(jsonSeparator))
     val locations = textsAndLocations.map(_.split(jsonSeparator).takeRight(2).mkString(jsonSeparator)) //location = pageNum::blockIdx
@@ -172,7 +83,11 @@ class CosmosTextReadingPipeline extends TextReadingPipeline {
       }
     }
 
-    mentionsWithLocations
+    // Resolve scenario context
+    val cosmosOrderer = new CosmosOrderer(mentionsWithLocations)
+    val scenarioContextEngine = new ContextEngine(windowSize = 3, mentionsWithLocations, cosmosOrderer)
+    val mentionsWithScenarioContext = mentionsWithLocations map scenarioContextEngine.resolveContext
+    mentionsWithScenarioContext
   }
 
   /**

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/OdinEngine.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/OdinEngine.scala
@@ -111,10 +111,10 @@ class OdinEngine(
 
   }
 
-  def extractFromText(text: String, keepText: Boolean = false, filename: Option[String]): Seq[Mention] = {
+  def extractFromText(text: String, keepText: Boolean = false, filename: Option[String]): (Document, Seq[Mention]) = {
     val doc = cleanAndAnnotate(text, keepText, filename)
     val odinMentions = extractFrom(doc)  // CTM: runs the Odin grammar
-    odinMentions  // CTM: collection of mentions ; to be converted to some form (json)
+    (doc, odinMentions)  // CTM: collection of mentions ; to be converted to some form (json)
   }
 
   // Supports web service, when existing entities are already known but from outside the project

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/OdinEngine.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/OdinEngine.scala
@@ -13,6 +13,7 @@ import org.ml4ai.skema.text_reading.data.{EdgeCaseParagraphPreprocessor, LightPr
 import org.ml4ai.skema.text_reading.entities.{EntityFinder, StringMatchEntityFinder}
 import org.ml4ai.skema.text_reading.utils.{DocumentFilter, FilterByLength, PassThroughFilter, TsvUtils}
 
+case class ExtractionResults(doc:Document, mentions:Seq[Mention])
 
 class OdinEngine(
                   val proc: Processor,
@@ -111,10 +112,10 @@ class OdinEngine(
 
   }
 
-  def extractFromText(text: String, keepText: Boolean = false, filename: Option[String]): (Document, Seq[Mention]) = {
+  def extractFromText(text: String, keepText: Boolean = false, filename: Option[String]): ExtractionResults = {
     val doc = cleanAndAnnotate(text, keepText, filename)
     val odinMentions = extractFrom(doc)  // CTM: runs the Odin grammar
-    (doc, odinMentions)  // CTM: collection of mentions ; to be converted to some form (json)
+    ExtractionResults(doc, odinMentions)  // CTM: collection of mentions ; to be converted to some form (json)
   }
 
   // Supports web service, when existing entities are already known but from outside the project

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/TextReadingPipeline.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/TextReadingPipeline.scala
@@ -85,7 +85,7 @@ class TextReadingPipeline extends Logging {
     */
   def extractMentions(text: String, fileName: Option[String]): (Document, Seq[Mention]) = {
     // Extract mentions and apply grounding
-    val (doc, mentions) = odinEngine.extractFromText(text, keepText = true, fileName)
+    val ExtractionResults(doc, mentions) = odinEngine.extractFromText(text, keepText = true, fileName)
     // Run grounding
     val groundedMentions = mentions.par.map {
       // Only ground arguments of events and relations, to save time

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/TextReadingPipeline.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/TextReadingPipeline.scala
@@ -1,0 +1,98 @@
+package org.ml4ai.skema.text_reading
+
+import ai.lum.common.ConfigUtils._
+import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
+import org.clulab.odin.{EventMention, Mention, RelationMention, TextBoundMention}
+import org.clulab.processors.Document
+import org.clulab.utils.Logging
+import org.ml4ai.grounding.{GroundingCandidate, MiraEmbeddingsGrounder}
+import org.ml4ai.skema.text_reading.attachments.GroundingAttachment
+
+import scala.util.matching.Regex
+
+class TextReadingPipeline extends Logging {
+  logger.info("Initializing the OdinEngine ...")
+
+  // Read the configuration from the files
+  val generalConfig: Config = ConfigFactory.load()
+  val readerType: String = generalConfig[String]("ReaderType")
+  val defaultConfig: Config = generalConfig[Config](readerType)
+  val config: Config = defaultConfig.withValue("preprocessorType", ConfigValueFactory.fromAnyRef("PassThrough"))
+  val groundingConfig: Config = generalConfig.getConfig("Grounding")
+
+  // Grounding parameters
+  private val ontologyFilePath = groundingConfig.getString("ontologyPath")
+  private val groundingAssignmentThreshold = groundingConfig.getDouble("assignmentThreshold")
+  private val grounder = MiraEmbeddingsGrounder(ontologyFilePath, None, lambda = 10, alpha = 1.0f) // TODO: Fix this @Enrique
+
+  val numberPattern: Regex = """^\.?(\d)+([.,]?\d*)*$""".r
+
+  // Odin Engine instantiation
+  private val odinEngine = OdinEngine.fromConfig(config)
+  // Initialize the odin engine
+  odinEngine.annotate("x = 10")
+
+  /**
+    * Assigns grounding elements to a mention
+    *
+    * @param m mention to ground
+    * @return instance of the mention with grounding attachment if applicable
+    */
+  def groundMention(m: Mention): Mention = m match {
+    case tbm: TextBoundMention =>
+      val isGrounded =
+        tbm.attachments.exists(!_.isInstanceOf[GroundingAttachment])
+
+      if (!isGrounded) {
+        // Don't ground unless it is not a number
+        numberPattern.findFirstIn(tbm.text.trim) match {
+          case None =>
+            val topGroundingCandidates = grounder.groundingCandidates(tbm.text).filter {
+              case GroundingCandidate(_, score) => score >= groundingAssignmentThreshold
+            }
+
+            if (topGroundingCandidates.nonEmpty)
+              tbm.withAttachment(new GroundingAttachment(topGroundingCandidates))
+            else
+              tbm
+          case Some(_) => tbm // If it is a number, then don't ground
+        }
+
+      }
+      else
+        tbm
+    case e: EventMention =>
+      val groundedArguments =
+        e.arguments.mapValues(_.map(groundMention))
+
+
+      e.copy(arguments = groundedArguments)
+    // This is duplicated while we fix the Mention trait to define the abstract method copy
+    case e: RelationMention =>
+      val groundedArguments =
+        e.arguments.mapValues(_.map(groundMention))
+
+      e.copy(arguments = groundedArguments)
+    case m => m
+  }
+
+  /**
+    * Runs the mention extraction engine on the  parameter
+    *
+    * @param text     to annotate
+    * @param fileName to identify the provenance of the document being annotated
+    * @return Annotated doc object and the mentions extracted by odin
+    */
+  def extractMentions(text: String, fileName: Option[String]): (Document, Seq[Mention]) = {
+    // Extract mentions and apply grounding
+    val (doc, mentions) = odinEngine.extractFromText(text, keepText = true, fileName)
+    // Run grounding
+    val groundedMentions = mentions.par.map {
+      // Only ground arguments of events and relations, to save time
+      case e@(_: EventMention | _: RelationMention) => groundMention(e)
+      case m => m
+    }.seq
+
+    (doc, groundedMentions)
+  }
+}

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/apps/AnnotateCosmosJsonFiles.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/apps/AnnotateCosmosJsonFiles.scala
@@ -33,7 +33,7 @@ object AnnotateCosmosJsonFiles extends App with Logging{
         if(inputFile.exists()){
           val outputFile = new File("extractions_" + inputFile.getName)
           logger.info(s"Extraction mentions from ${inputFile.getAbsolutePath}")
-          val jsonContents = textReadingPipeline.serializeToJson(inputFile.getAbsolutePath)
+          val jsonContents = textReadingPipeline.extractMentionsFromJsonAndSerialize(inputFile.getAbsolutePath)
           val writer = new PrintWriter(new FileOutputStream(outputFile))
           writer.write(jsonContents)
           writer.close()

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/apps/ExtractAndAlign.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/apps/ExtractAndAlign.scala
@@ -404,7 +404,7 @@ object ExtractAndAlign {
       logger.info(s"Extracting from ${file.getName}")
       val texts: Seq[String] = dataLoader.loadFile(file)
       // Route text based on the amount of sentence punctuation and the # of numbers (too many numbers = non-prose from the paper)
-      texts.flatMap(text => textRouter.route(text).extractFromText(text, filename = Some(file.getName))._2)
+      texts.flatMap(text => textRouter.route(text).extractFromText(text, filename = Some(file.getName)).mentions)
     }
     logger.info(s"Extracted ${textMentions.length} text mentions")
     val onlyEventsAndRelations = textMentions.seq.filter(m => m.matches("EventMention") || m.matches("RelationMention"))

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/apps/ExtractAndAlign.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/apps/ExtractAndAlign.scala
@@ -404,7 +404,7 @@ object ExtractAndAlign {
       logger.info(s"Extracting from ${file.getName}")
       val texts: Seq[String] = dataLoader.loadFile(file)
       // Route text based on the amount of sentence punctuation and the # of numbers (too many numbers = non-prose from the paper)
-      texts.flatMap(text => textRouter.route(text).extractFromText(text, filename = Some(file.getName)))
+      texts.flatMap(text => textRouter.route(text).extractFromText(text, filename = Some(file.getName))._2)
     }
     logger.info(s"Extracted ${textMentions.length} text mentions")
     val onlyEventsAndRelations = textMentions.seq.filter(m => m.matches("EventMention") || m.matches("RelationMention"))

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/attachments/AutomatesAttachment.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/attachments/AutomatesAttachment.scala
@@ -42,25 +42,22 @@ class LocationContextAttachment(locations:Seq[Mention]) extends AutomatesAttachm
     )
   })
 
-  override def toUJson: Value = ujson.Arr(locations map {
-    l => ujson.Obj(
-      "scenarioLocation" -> l.text
-    )
-  })
+  override def toUJson: Value = ujson.Obj(
+    "scenarioLocation" -> (locations map (_.text)).distinct
+  )
 }
 
-class TimeContextAttachment(locations:Seq[Mention]) extends AutomatesAttachment {
-  override def toJson: JsValue = Json.arr(locations map {
+class TimeContextAttachment(times:Seq[Mention]) extends AutomatesAttachment {
+  override def toJson: JsValue = Json.arr(times map {
     l => Json.obj(
       "scenarioTime" -> l.text
     )
   })
 
-  override def toUJson: Value = ujson.Arr(locations map {
-    l => ujson.Obj(
-      "scenarioTime" -> l.text
-    )
-  })
+
+  override def toUJson: Value = ujson.Obj(
+    "scenarioTime" -> (times map (_.text)).distinct
+  )
 }
 
 class MentionLocationAttachment(val filename: String, val  pageNum: Seq[Int], val blockIdx: Seq[Int], attType: String) extends AutomatesAttachment {

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/attachments/AutomatesAttachment.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/attachments/AutomatesAttachment.scala
@@ -1,6 +1,6 @@
 package org.ml4ai.skema.text_reading.attachments
 
-import org.clulab.odin.Attachment
+import org.clulab.odin.{Attachment, Mention}
 import org.ml4ai.grounding.GroundingCandidate
 import org.ml4ai.skema.text_reading.quantities.Interval
 import play.api.libs.json.{JsValue, Json}
@@ -35,7 +35,35 @@ class GroundingAttachment(candidates:Seq[GroundingCandidate]) extends AutomatesA
   })
 }
 
-class MentionLocationAttachment(filename: String, pageNum: Seq[Int], blockIdx: Seq[Int], attType: String) extends AutomatesAttachment {
+class LocationContextAttachment(locations:Seq[Mention]) extends AutomatesAttachment {
+  override def toJson: JsValue = Json.arr(locations map {
+    l => Json.obj(
+      "scenarioLocation" -> l.text
+    )
+  })
+
+  override def toUJson: Value = ujson.Arr(locations map {
+    l => ujson.Obj(
+      "scenarioLocation" -> l.text
+    )
+  })
+}
+
+class TimeContextAttachment(locations:Seq[Mention]) extends AutomatesAttachment {
+  override def toJson: JsValue = Json.arr(locations map {
+    l => Json.obj(
+      "scenarioTime" -> l.text
+    )
+  })
+
+  override def toUJson: Value = ujson.Arr(locations map {
+    l => ujson.Obj(
+      "scenarioTime" -> l.text
+    )
+  })
+}
+
+class MentionLocationAttachment(val filename: String, val  pageNum: Seq[Int], val blockIdx: Seq[Int], attType: String) extends AutomatesAttachment {
 
   override def toJson: JsValue =  Json.obj(
     "filename" -> filename,

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/scenario_context/ContextEngine.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/scenario_context/ContextEngine.scala
@@ -33,9 +33,10 @@ class ContextEngine(windowSize:Int, documentMentions:Iterable[Mention], orderer:
             val contextMentions = mentionsMap.getOrElse(sentenceIndex, Seq.empty)
             contextMentions
         }.groupBy(_.label).map {
-          case (label, mentions) if label == "Location" => new LocationContextAttachment(mentions)
+          case (label, mentions) if label == "Location" =>
+            new LocationContextAttachment(mentions)
           case (label, mentions) if label == "Date" => new TimeContextAttachment(mentions)
-        }.toSeq
+        }.toSeq.distinct
 
       m match {
         case evt: EventMention =>

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/scenario_context/ContextEngine.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/scenario_context/ContextEngine.scala
@@ -11,7 +11,7 @@ class ContextEngine(windowSize:Int, documentMentions:Iterable[Mention], orderer:
 
  // Select TB mentions of Location and Date type
   private val candidateMentions = documentMentions.filter{
-     case tb:TextBoundMention if contextLabels contains tb.label => true
+     case tb:TextBoundMention if contextLabels(tb.label) => true
      case _ => false
   }
 
@@ -32,10 +32,10 @@ class ContextEngine(windowSize:Int, documentMentions:Iterable[Mention], orderer:
           sentenceIndex =>
             val contextMentions = mentionsMap.getOrElse(sentenceIndex, Seq.empty)
             contextMentions
-        }.groupBy(_.label).map {
-          case (label, mentions) if label == "Location" =>
+        }.groupBy(_.label).collect {
+          case ("Location", mentions) =>
             new LocationContextAttachment(mentions)
-          case (label, mentions) if label == "Date" => new TimeContextAttachment(mentions)
+          case ("Date", mentions) => new TimeContextAttachment(mentions)
         }.toSeq.distinct
 
       m match {

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/scenario_context/ContextEngine.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/scenario_context/ContextEngine.scala
@@ -1,0 +1,56 @@
+package org.ml4ai.skema.text_reading.scenario_context
+
+import org.clulab.odin.{EventMention, Mention, RelationMention, TextBoundMention}
+import org.ml4ai.skema.text_reading.attachments.{LocationContextAttachment, TimeContextAttachment}
+
+class ContextEngine(windowSize:Int, documentMentions:Iterable[Mention], orderer: MentionOrderer) {
+
+
+  private val contextLabels = Set("Location", "Date")
+
+
+ // Select TB mentions of Location and Date type
+  private val candidateMentions = documentMentions.filter{
+     case tb:TextBoundMention if contextLabels contains tb.label => true
+     case _ => false
+  }
+
+  private val mentionsMap: Map[Int, Iterable[Mention]] = candidateMentions.groupBy(orderer.resolveLinearOrder)
+
+  private val maxIndex = mentionsMap.keys.max
+
+
+  def resolveContext(m:Mention): Mention =  {
+
+    if(m.isInstanceOf[EventMention] || m.isInstanceOf[RelationMention]) {
+      val location = orderer.resolveLinearOrder(m)
+      val start = Math.max(0, location - windowSize)
+      val end = Math.min(maxIndex, location + windowSize)
+
+      val contextAttachments =
+        (start to end).flatMap {
+          sentenceIndex =>
+            val contextMentions = mentionsMap.getOrElse(sentenceIndex, Seq.empty)
+            contextMentions
+        }.groupBy(_.label).map {
+          case (label, mentions) if label == "Location" => new LocationContextAttachment(mentions)
+          case (label, mentions) if label == "Date" => new TimeContextAttachment(mentions)
+        }.toSeq
+
+      m match {
+        case evt: EventMention =>
+          // Add the attachments to the mention
+          evt.newWithAttachments(contextAttachments)
+
+        case rel: RelationMention =>
+          // Add the attachments to the mention
+          rel.newWithAttachments(contextAttachments)
+        case el => el // This is just to complete the match statement, should never pass through here
+      }
+    }
+    else
+      m
+
+  }
+
+}

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/scenario_context/CosmosOrderer.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/scenario_context/CosmosOrderer.scala
@@ -1,0 +1,51 @@
+package org.ml4ai.skema.text_reading.scenario_context
+import org.apache.poi.openxml4j.exceptions.InvalidOperationException
+import org.clulab.odin.Mention
+import org.ml4ai.skema.text_reading.attachments.MentionLocationAttachment
+
+/**
+  * Implementation to resolve ordering for mentions that come from a Cosmos Json file.
+  * Will use the `MentionLocationAttachment` to inform the final linear order using page numbers
+  *
+  * @param ms All the mentions from the Cosmos Json, used to establish the order bounds
+  */
+class CosmosOrderer(ms:Iterable[Mention]) extends MentionOrderer {
+
+  private def getMentionLocation(m:Mention) = m.attachments.filter(_.isInstanceOf[MentionLocationAttachment]).head.asInstanceOf[MentionLocationAttachment]
+
+  private case class OrderingHelper(page:Int, block:Int, sent:Int, s:Int  = 0)
+
+  // Will use the `MentionLocationAttachment` on each mention to generate an offset for each (page, block)
+  private val offsets =
+    ms.toSeq.map(
+      m => {
+        if (!m.attachments.exists(_.isInstanceOf[MentionLocationAttachment]))
+          throw new InvalidOperationException("Mention without MentionLocationAttachment")
+
+        val location = getMentionLocation(m)
+        val page = location.pageNum.head
+        val block = location.blockIdx.head
+        val numSentences = m.document.sentences.length
+        OrderingHelper(page, block, numSentences)
+      }
+    ).distinct.sortBy{
+      case OrderingHelper(p,b,s, _) => (p, b, s)
+    }.scan(OrderingHelper(0, 0, 0))(
+      (prev, curr) => {
+        OrderingHelper(curr.page, curr.block, prev.s, prev.s+curr.sent)
+      }
+    ).map{case OrderingHelper(p, b, s, _) => (p, b) -> s}.toMap
+
+  /**
+    * Takes a mention and linearizes its order for context assignment.
+    * This function will encapsulate the ordering logic in the case of a non-trivial ordering, i.e. reading from a Cosmos Json file
+    *
+    * @param m mention to resolve its linear order
+    * @return Linear order of appearance in the encapsulating document. Roughly equivalent of the sentence number in which the mention appears if the source document is a plain text file
+    */
+  override def resolveLinearOrder(m: Mention): Int = {
+    val location = getMentionLocation(m)
+    val offset = offsets((location.pageNum.head, location.blockIdx.head)) // TODO: Make these scalars, not arrays
+    offset + m.sentence
+  }
+}

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/scenario_context/MentionOrderer.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/scenario_context/MentionOrderer.scala
@@ -1,0 +1,33 @@
+package org.ml4ai.skema.text_reading.scenario_context
+
+import org.clulab.odin.Mention
+
+/**
+  * Trait used to implement a partial order to mentions contained in a "document"
+  * Document could mean a plan string with multiple sentences, a pdf, a cosmos json, etc.
+  */
+trait MentionOrderer {
+  /**
+    * Takes a mention and linearizes its order for context assignment.
+    * This function will encapsulate the ordering logic in the case of a non-trivial ordering, i.e. reading from a Cosmos Json file
+    * @param m mention to resolve its linear order
+    * @return Linear order of appearance in the encapsulating document. Roughly equivalent of the sentence number in which the mention appears if the source document is a plain text file
+    */
+  def resolveLinearOrder(m:Mention):Int
+}
+
+/**
+  * Default implementation that just looks at the sentence index to resolve the ordering.
+  * This implementation could be used when the input document is a plain string, without any additional structure
+  */
+object SentenceIndexOrderer extends MentionOrderer{
+  /**
+    * Takes a mention and linearizes its order for context assignment.
+    * This function will encapsulate the ordering logic in the case of a non-trivial ordering, i.e. reading from a Cosmos Json file
+    *
+    * @param m mention to resolve its linear order
+    * @return Sentence index of the parameter
+    */
+  override def resolveLinearOrder(m: Mention): Int = m.sentence
+}
+

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/utils/MentionUtils.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/utils/MentionUtils.scala
@@ -44,7 +44,7 @@ object MentionUtils {
 
   def getMentionsWithoutLocations(texts: Seq[String], file: File, reader: OdinEngine): Seq[Mention] = {
     // this is for science parse
-    val mentions = texts.flatMap(t => reader.extractFromText(t, filename = Some(file.getName)))
+    val mentions = texts.flatMap(t => reader.extractFromText(t, filename = Some(file.getName))._2)
     // most fields here will be null, but there will be a filename field; doing this so that all mentions, regardless of whether they have dtailed location (in the document) can be processed the same way
     val mentionsWithLocations = new ArrayBuffer[Mention]()
     for (m <- mentions) {
@@ -64,7 +64,7 @@ object MentionUtils {
     val locations = texts.map(_.split("<::>").takeRight(2).mkString("<::>")) //location = pageNum::blockIdx
     val mentions = for (tf <- textsAndFilenames) yield {
       val Array(text, filename) = tf.split("<::>")
-      reader.extractFromText(text, keepText = true, Some(filename))
+      reader.extractFromText(text, keepText = true, Some(filename))._2
     }
     // store location information from cosmos as an attachment for each mention
     val menWInd = mentions.zipWithIndex

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/utils/MentionUtils.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/utils/MentionUtils.scala
@@ -44,7 +44,7 @@ object MentionUtils {
 
   def getMentionsWithoutLocations(texts: Seq[String], file: File, reader: OdinEngine): Seq[Mention] = {
     // this is for science parse
-    val mentions = texts.flatMap(t => reader.extractFromText(t, filename = Some(file.getName))._2)
+    val mentions = texts.flatMap(t => reader.extractFromText(t, filename = Some(file.getName)).mentions)
     // most fields here will be null, but there will be a filename field; doing this so that all mentions, regardless of whether they have dtailed location (in the document) can be processed the same way
     val mentionsWithLocations = new ArrayBuffer[Mention]()
     for (m <- mentions) {
@@ -64,7 +64,7 @@ object MentionUtils {
     val locations = texts.map(_.split("<::>").takeRight(2).mkString("<::>")) //location = pageNum::blockIdx
     val mentions = for (tf <- textsAndFilenames) yield {
       val Array(text, filename) = tf.split("<::>")
-      reader.extractFromText(text, keepText = true, Some(filename))._2
+      reader.extractFromText(text, keepText = true, Some(filename)).mentions
     }
     // store location information from cosmos as an attachment for each mention
     val menWInd = mentions.zipWithIndex

--- a/skema/text_reading/text_reading/src/test/scala/org/ml4ai/skema/test/TestUtils.scala
+++ b/skema/text_reading/text_reading/src/test/scala/org/ml4ai/skema/test/TestUtils.scala
@@ -21,7 +21,7 @@ object TestUtils {
 
   // This is the standard way to extract mentions for testing
   def extractMentions(ieSystem: OdinEngine, text: String): Seq[Mention] = {
-    ieSystem.extractFromText(text, true, None)
+    ieSystem.extractFromText(text, true, None)._2
   }
 
   def newOdinSystem(config: Config): OdinEngine = this.synchronized {

--- a/skema/text_reading/text_reading/src/test/scala/org/ml4ai/skema/test/TestUtils.scala
+++ b/skema/text_reading/text_reading/src/test/scala/org/ml4ai/skema/test/TestUtils.scala
@@ -21,7 +21,7 @@ object TestUtils {
 
   // This is the standard way to extract mentions for testing
   def extractMentions(ieSystem: OdinEngine, text: String): Seq[Mention] = {
-    ieSystem.extractFromText(text, true, None)._2
+    ieSystem.extractFromText(text, true, None).mentions
   }
 
   def newOdinSystem(config: Config): OdinEngine = this.synchronized {

--- a/skema/text_reading/text_reading/src/test/scala/org/ml4ai/skema/text_reading/text/TestDescriptions.scala
+++ b/skema/text_reading/text_reading/src/test/scala/org/ml4ai/skema/text_reading/text/TestDescriptions.scala
@@ -394,7 +394,7 @@ class TestDescriptions extends ExtractionTest {
 //    val desired = Seq(
 //
 //    )
-//    val mentions = extractMentions(t9c)
+//    val mentions = extractMentionsFromCosmosJson(t9c)
 //    testDescriptionEvent(mentions, desired)
 //  }
 

--- a/skema/text_reading/text_reading/src/test/scala/org/ml4ai/skema/text_reading/text/TestIdentifiers.scala
+++ b/skema/text_reading/text_reading/src/test/scala/org/ml4ai/skema/text_reading/text/TestIdentifiers.scala
@@ -263,7 +263,7 @@ class TestIdentifiers extends ExtractionTest {
 //  val tX = ""
 //  passingTest should "extract identifiers from tX: ${tX}" taggedAs(Somebody) in {
 //    val desired = Seq()
-//    val mentions = extractMentions(tX)
+//    val mentions = extractMentionsFromCosmosJson(tX)
 //    testTextBoundMention(mentions, IDENTIFIER_LABEL, desired)
 //  }
 

--- a/skema/text_reading/text_reading/src/test/scala/org/ml4ai/skema/text_reading/text/TestParameterSetting.scala
+++ b/skema/text_reading/text_reading/src/test/scala/org/ml4ai/skema/text_reading/text/TestParameterSetting.scala
@@ -33,7 +33,7 @@ class TestParameterSetting  extends ExtractionTest {
 //      "Kcbmax" -> Seq("0.9", "1.4"), // todo: depends on how we decide to return intervals
 //      "Kcbmax" -> Seq("1.15") //todo is this going to break if there are two kcbmax values -- Yes, see comment in t8
 //    )
-//    val mentions = extractMentions(t2a)
+//    val mentions = extractMentionsFromCosmosJson(t2a)
 //    testParameterSettingEvent(mentions, desired)
 //  }
 
@@ -88,7 +88,7 @@ class TestParameterSetting  extends ExtractionTest {
 //    val desired = Seq(
 //      "height" -> Seq("2.0 m") //todo: attaching value and unit? spelt out term?
 //    )
-//    val mentions = extractMentions(t7)
+//    val mentions = extractMentionsFromCosmosJson(t7)
 //    testParameterSettingEvent(mentions, desired)
 //  }
 
@@ -174,7 +174,7 @@ class TestParameterSetting  extends ExtractionTest {
 //    val desired = Seq(
 //      "ETsz" -> Seq("2.45")
 //    )
-//    val mentions = extractMentions(t2b)
+//    val mentions = extractMentionsFromCosmosJson(t2b)
 //    testParameterSettingEvent(mentions, desired)
 //  }
 
@@ -361,7 +361,7 @@ class TestParameterSetting  extends ExtractionTest {
 //    val desired = Seq(
 //      "The inverse ratio of λ ρw times energy flux" -> Seq("1.0")
 //    )
-//    val mentions = extractMentions(t4b)
+//    val mentions = extractMentionsFromCosmosJson(t4b)
 //    testParameterSettingEvent(mentions, desired)
 //  }
 

--- a/skema/text_reading/text_reading/src/test/scala/org/ml4ai/skema/text_reading/text/TestParameterSettingInterval.scala
+++ b/skema/text_reading/text_reading/src/test/scala/org/ml4ai/skema/text_reading/text/TestParameterSettingInterval.scala
@@ -134,7 +134,7 @@ class TestParameterSettingEventInterval  extends ExtractionTest {
 //      "KEP" -> Seq("0", "0.8") //todo: need a rule for "range from"
 //    )
 //
-//    val mentions = extractMentions(t3a)
+//    val mentions = extractMentionsFromCosmosJson(t3a)
 //    testParameterSettingEventInterval(mentions, desired)
 //  }
 

--- a/skema/text_reading/text_reading/webapp/app/controllers/HomeController.scala
+++ b/skema/text_reading/text_reading/webapp/app/controllers/HomeController.scala
@@ -210,7 +210,7 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
       scienceParseDoc.sections.get.map(_.headingAndText) ++ scienceParseDoc.abstractText
     } else scienceParseDoc.abstractText.toSeq
     logger.info("Finished converting to text")
-    val mentions = texts.flatMap(t => ieSystem.extractFromText(t, keepText = true, filename = Some(pdfFile)))
+    val mentions = texts.flatMap(t => ieSystem.extractFromText(t, keepText = true, filename = Some(pdfFile))._2)
     val outFile = json("outfile").str
     AutomatesExporter(outFile).export(mentions)
     //    mentions.saveJSON(outFile, pretty=true)
@@ -230,7 +230,7 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
     logger.info(s"Extracting mentions from $jsonFile")
     val loader = new ScienceParsedDataLoader
     val texts = loader.loadFile(jsonFile)
-    val mentions = texts.flatMap(t => ieSystem.extractFromText(t, keepText = true, filename = Some(jsonFile)))
+    val mentions = texts.flatMap(t => ieSystem.extractFromText(t, keepText = true, filename = Some(jsonFile))._2)
     val outFile = json("outfile").str
     AutomatesExporter(outFile).export(mentions)
     Ok("")
@@ -244,7 +244,7 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
     val jsonPath = pathJson("pathToCosmosJson").str
     logger.info(s"Extracting mentions from $jsonPath")
 
-    val exportedData = cosmosPipeline.serializeToJson(jsonPath)
+    val exportedData = cosmosPipeline.extractMentionsFromJsonAndSerialize(jsonPath)
 
     Ok(exportedData)
 
@@ -426,15 +426,22 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
   def processPlayText(ieSystem: OdinEngine, text: String, gazetteer: Option[Seq[String]] = None): (Document, Vector[Mention]) = {
     // preprocessing
     logger.info(s"Processing sentence : ${text}")
-    val doc = ieSystem.cleanAndAnnotate(text, keepText = true, filename = None)
+//    val doc = ieSystem.cleanAndAnnotate(text, keepText = true, filename = None)
+//
+//    logger.info(s"DOC : ${doc}")
+//    // extract mentions from annotated document
+//    val mentions = if (gazetteer.isDefined) {
+//      ieSystem.extractFromDocWithGazetteer(doc, gazetteer = gazetteer.get)
+//    } else {
+//      ieSystem.extractFrom(doc)
+//    }
+//    val sorted = mentions.sortBy(m => (m.sentence, m.getClass.getSimpleName)).toVector
+//
+//    logger.info(s"Done extracting the mentions ... ")
+//    logger.info(s"They are : ${mentions.map(m => m.text).mkString(",\t")}")
 
-    logger.info(s"DOC : ${doc}")
-    // extract mentions from annotated document
-    val mentions = if (gazetteer.isDefined) {
-      ieSystem.extractFromDocWithGazetteer(doc, gazetteer = gazetteer.get)
-    } else {
-      ieSystem.extractFrom(doc)
-    }
+    val (doc, mentions) = cosmosPipeline.extractMentions(text, None)
+
     val sorted = mentions.sortBy(m => (m.sentence, m.getClass.getSimpleName)).toVector
 
     logger.info(s"Done extracting the mentions ... ")
@@ -694,7 +701,7 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
         case m: RelationMention => new TextBoundMention(m.labels, m.tokenInterval, m.sentence, m.document, m.keep, m.foundBy)
         case m: EventMention => m.trigger
       }
-      mkArgMention(argRole, s"T${tbmToId(arg)}")
+      mkArgMention(argRole, s"T${tbmToId.getOrElse(arg, "X")}")
     }
     args.toSeq
   }

--- a/skema/text_reading/text_reading/webapp/app/controllers/HomeController.scala
+++ b/skema/text_reading/text_reading/webapp/app/controllers/HomeController.scala
@@ -210,7 +210,7 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
       scienceParseDoc.sections.get.map(_.headingAndText) ++ scienceParseDoc.abstractText
     } else scienceParseDoc.abstractText.toSeq
     logger.info("Finished converting to text")
-    val mentions = texts.flatMap(t => ieSystem.extractFromText(t, keepText = true, filename = Some(pdfFile))._2)
+    val mentions = texts.flatMap(t => ieSystem.extractFromText(t, keepText = true, filename = Some(pdfFile)).mentions)
     val outFile = json("outfile").str
     AutomatesExporter(outFile).export(mentions)
     //    mentions.saveJSON(outFile, pretty=true)
@@ -230,7 +230,7 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
     logger.info(s"Extracting mentions from $jsonFile")
     val loader = new ScienceParsedDataLoader
     val texts = loader.loadFile(jsonFile)
-    val mentions = texts.flatMap(t => ieSystem.extractFromText(t, keepText = true, filename = Some(jsonFile))._2)
+    val mentions = texts.flatMap(t => ieSystem.extractFromText(t, keepText = true, filename = Some(jsonFile)).mentions)
     val outFile = json("outfile").str
     AutomatesExporter(outFile).export(mentions)
     Ok("")


### PR DESCRIPTION
This is the first implementation of Scenario Context.

The two main abstractions are: `ContextEngine`, which looks around a window of sentences in order to attach location and time scenario context to relation and event mentions; and `MentionOrderer` which is used to abstract the notion of a linear partial ordering of appearance for the mentions, regardless of the source. This way, we can sort the mentions that come from a Cosmos document, which has pages and blocks within pages, and look around efficiently at the time of context resolution.