### PR TITLE
Rename 'op' field to 'ops' in PreExp and Expression structs

### DIFF
--- a/skema/skema-rs/mathml/src/expression.rs
+++ b/skema/skema-rs/mathml/src/expression.rs
@@ -33,15 +33,8 @@ enum Expr {
 
 /// Intermediate data structure to support the generation of graphs of mathematical expressions
 #[derive(Debug, Default, PartialEq, Clone)]
-pub struct Operators {
-    unary: Option<Operator>,
-    nary: Vec<Operator>,
-}
-
-/// Intermediate data structure to support the generation of graphs of mathematical expressions
-#[derive(Debug, Default, PartialEq, Clone)]
 pub struct PreExp {
-    ops: Operators,
+    ops: Vec<Operator>,
     args: Vec<Expr>,
     name: String,
 }

--- a/skema/skema-rs/mathml/src/expression.rs
+++ b/skema/skema-rs/mathml/src/expression.rs
@@ -25,7 +25,7 @@ enum Atom {
 enum Expr {
     Atom(Atom),
     Expression {
-        op: Vec<Operator>,
+        ops: Vec<Operator>,
         args: Vec<Expr>,
         name: String,
     },
@@ -34,7 +34,7 @@ enum Expr {
 /// Intermediate data structure to support the generation of graphs of mathematical expressions
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct PreExp {
-    op: Vec<Operator>,
+    ops: Vec<Operator>,
     args: Vec<Expr>,
     name: String,
 }
@@ -61,8 +61,8 @@ pub fn is_derivative(
 /// Identify if there is an implicit multiplication operator, and if so, add an
 /// explicit multiplication operator.
 fn insert_explicit_multiplication_operator(pre: &mut PreExp) {
-    if pre.args.len() >= pre.op.len() {
-        pre.op.push(Operator::Multiply);
+    if pre.args.len() >= pre.ops.len() {
+        pre.ops.push(Operator::Multiply);
     }
 }
 
@@ -87,8 +87,8 @@ impl MathExpression {
                     }
                 }
                 // deal with the invisible multiply operator
-                if pre.args.len() >= pre.op.len() {
-                    pre.op.push(Operator::Multiply);
+                if pre.args.len() >= pre.ops.len() {
+                    pre.ops.push(Operator::Multiply);
                 }
                 pre.args
                     .push(Expr::Atom(Atom::Identifier(x.replace(' ', ""))));
@@ -101,23 +101,23 @@ impl MathExpression {
             Mo(x) => {
                 // Insert a temporary placeholder identifier to deal with unary minus operation.
                 // The placeholder will be removed later.
-                if x == Operator::Subtract && pre.op.len() > pre.args.len() {
-                    pre.op.push(x);
+                if x == Operator::Subtract && pre.ops.len() > pre.args.len() {
+                    pre.ops.push(x);
                     pre.args
                         .push(Expr::Atom(Atom::Identifier("place_holder".to_string())));
                 } else {
-                    pre.op.push(x);
+                    pre.ops.push(x);
                 }
             }
             Mrow(xs) => {
                 insert_explicit_multiplication_operator(pre);
                 let mut pre_exp = PreExp::default();
-                pre_exp.op.push(Operator::Other("".to_string()));
+                pre_exp.ops.push(Operator::Other("".to_string()));
                 for x in xs {
                     x.to_expr(&mut pre_exp);
                 }
                 pre.args.push(Expr::Expression {
-                    op: pre_exp.op,
+                    ops: pre_exp.ops,
                     args: pre_exp.args,
                     name: "".to_string(),
                 });
@@ -125,14 +125,14 @@ impl MathExpression {
             Msubsup(xs1, xs2, xs3) => {
                 insert_explicit_multiplication_operator(pre);
                 let mut pre_exp = PreExp::default();
-                pre_exp.op.push(Operator::Other("".to_string()));
-                pre_exp.op.push(Operator::Other("_".to_string()));
+                pre_exp.ops.push(Operator::Other("".to_string()));
+                pre_exp.ops.push(Operator::Other("_".to_string()));
                 xs1.to_expr(&mut pre_exp);
-                pre_exp.op.push(Operator::Other("^".to_string()));
+                pre_exp.ops.push(Operator::Other("^".to_string()));
                 xs2.to_expr(&mut pre_exp);
                 xs3.to_expr(&mut pre_exp);
                 pre.args.push(Expr::Expression {
-                    op: pre_exp.op,
+                    ops: pre_exp.ops,
                     args: pre_exp.args,
                     name: "".to_string(),
                 });
@@ -140,10 +140,10 @@ impl MathExpression {
             Msqrt(xs) => {
                 insert_explicit_multiplication_operator(pre);
                 let mut pre_exp = PreExp::default();
-                pre_exp.op.push(Operator::Sqrt);
+                pre_exp.ops.push(Operator::Sqrt);
                 xs.to_expr(&mut pre_exp);
                 pre.args.push(Expr::Expression {
-                    op: pre_exp.op,
+                    ops: pre_exp.ops,
                     args: pre_exp.args,
                     name: "".to_string(),
                 });
@@ -152,15 +152,15 @@ impl MathExpression {
                 insert_explicit_multiplication_operator(pre);
                 let mut pre_exp = PreExp::default();
                 if is_derivative(&mut xs1, &mut xs2) {
-                    pre_exp.op.push(Operator::Other("derivative".to_string()));
+                    pre_exp.ops.push(Operator::Other("derivative".to_string()));
                 } else {
-                    pre_exp.op.push(Operator::Other("".to_string()));
+                    pre_exp.ops.push(Operator::Other("".to_string()));
                 }
                 xs1.to_expr(&mut pre_exp);
-                pre_exp.op.push(Operator::Divide);
+                pre_exp.ops.push(Operator::Divide);
                 xs2.to_expr(&mut pre_exp);
                 pre.args.push(Expr::Expression {
-                    op: pre_exp.op,
+                    ops: pre_exp.ops,
                     args: pre_exp.args,
                     name: "".to_string(),
                 });
@@ -168,12 +168,12 @@ impl MathExpression {
             Msup(xs1, xs2) => {
                 insert_explicit_multiplication_operator(pre);
                 let mut pre_exp = PreExp::default();
-                pre_exp.op.push(Operator::Other("".to_string()));
+                pre_exp.ops.push(Operator::Other("".to_string()));
                 xs1.to_expr(&mut pre_exp);
-                pre_exp.op.push(Operator::Other("^".to_string()));
+                pre_exp.ops.push(Operator::Other("^".to_string()));
                 xs2.to_expr(&mut pre_exp);
                 pre.args.push(Expr::Expression {
-                    op: pre_exp.op,
+                    ops: pre_exp.ops,
                     args: pre_exp.args,
                     name: "".to_string(),
                 });
@@ -181,12 +181,12 @@ impl MathExpression {
             Mover(xs1, xs2) => {
                 insert_explicit_multiplication_operator(pre);
                 let mut pre_exp = PreExp::default();
-                pre_exp.op.push(Operator::Other("".to_string()));
+                pre_exp.ops.push(Operator::Other("".to_string()));
                 xs1.to_expr(&mut pre_exp);
                 xs2.to_expr(&mut pre_exp);
-                pre_exp.op.remove(0);
+                pre_exp.ops.remove(0);
                 pre.args.push(Expr::Expression {
-                    op: pre_exp.op,
+                    ops: pre_exp.ops,
                     args: pre_exp.args,
                     name: "".to_string(),
                 });
@@ -199,11 +199,11 @@ impl MathExpression {
 
     pub fn to_graph(self) -> MathExpressionGraph<'static> {
         let mut pre_exp = PreExp {
-            op: Vec::<Operator>::new(),
+            ops: Vec::<Operator>::new(),
             args: Vec::<Expr>::new(),
             name: "root".to_string(),
         };
-        pre_exp.op.push(Operator::Other("root".to_string()));
+        pre_exp.ops.push(Operator::Other("root".to_string()));
         self.to_expr(&mut pre_exp);
         pre_exp.group_expr();
         pre_exp.collapse_expr();
@@ -216,44 +216,44 @@ impl MathExpression {
 impl Expr {
     /// Group expression by multiplication and division operations.
     fn group_expr(&mut self) {
-        if let Expr::Expression { op, args, .. } = self {
+        if let Expr::Expression { ops, args, .. } = self {
             let mut removed_idx = Vec::new();
-            let op_copy = op.clone();
+            let op_copy = ops.clone();
             let args_copy = args.clone();
-            if op.len() > 2 {
+            if ops.len() > 2 {
                 let mut start_idx: i32 = -1;
                 let mut end_idx: i32 = -1;
                 let mut new_exp = Expr::Expression {
-                    op: vec![Operator::Other("".to_string())],
+                    ops: vec![Operator::Other("".to_string())],
                     args: Vec::<Expr>::new(),
                     name: "".to_string(),
                 };
-                for o in 0..=op.len() - 1 {
-                    if op[o] == Operator::Multiply || op[o] == Operator::Divide {
+                for o in 0..=ops.len() - 1 {
+                    if ops[o] == Operator::Multiply || ops[o] == Operator::Divide {
                         removed_idx.push(o);
                         if start_idx == -1 {
                             start_idx = o as i32;
                             end_idx = o as i32;
-                            if let Expr::Expression { op, args, .. } = &mut new_exp {
-                                op.push(op_copy[o].clone());
+                            if let Expr::Expression { ops, args, .. } = &mut new_exp {
+                                ops.push(op_copy[o].clone());
                                 args.push(args_copy[o - 1].clone());
                                 args.push(args_copy[o].clone());
                             }
                         } else if o as i32 - end_idx == 1 {
                             end_idx = o as i32;
-                            if let Expr::Expression { op, args, .. } = &mut new_exp {
-                                op.push(op_copy[o].clone());
+                            if let Expr::Expression { ops, args, .. } = &mut new_exp {
+                                ops.push(op_copy[o].clone());
                                 args.push(args_copy[o].clone())
                             }
                         } else {
                             args[start_idx as usize - 1] = new_exp.clone();
                             new_exp = Expr::Expression {
-                                op: vec![Operator::Other("".to_string())],
+                                ops: vec![Operator::Other("".to_string())],
                                 args: Vec::<Expr>::new(),
                                 name: "".to_string(),
                             };
-                            if let Expr::Expression { op, args, .. } = &mut new_exp {
-                                op.push(op_copy[o].clone());
+                            if let Expr::Expression { ops, args, .. } = &mut new_exp {
+                                ops.push(op_copy[o].clone());
                                 args.push(args_copy[o - 1].clone());
                                 args.push(args_copy[o].clone());
                             }
@@ -263,17 +263,17 @@ impl Expr {
                     }
                 }
 
-                if removed_idx.len() == op.len() - 1 {
+                if removed_idx.len() == ops.len() - 1 {
                     return;
                 }
 
-                if let Expr::Expression { op, .. } = &mut new_exp {
-                    if !op.is_empty() && start_idx > 0 {
+                if let Expr::Expression { ops, .. } = &mut new_exp {
+                    if !ops.is_empty() && start_idx > 0 {
                         args[start_idx as usize - 1] = new_exp.clone();
                     }
                 }
                 for ri in removed_idx.iter().rev() {
-                    op.remove(*ri);
+                    ops.remove(*ri);
                     args.remove(*ri);
                 }
             }
@@ -289,32 +289,32 @@ impl Expr {
     /// If the current term's operators are all multiplication or division, check if it contains
     /// nested all multiplication or division terms inside. If so, collapse them into a single term.
     fn collapse_expr(&mut self) {
-        if let Expr::Expression { op, args, .. } = self {
-            let mut op_copy = op.clone();
+        if let Expr::Expression { ops, args, .. } = self {
+            let mut op_copy = ops.clone();
             let mut args_copy = args.clone();
 
             let mut shift = 0;
-            if all_ops_are_mult_or_div(op.to_vec()) && op.len() > 1 {
+            if all_ops_are_mult_or_div(ops.to_vec()) && ops.len() > 1 {
                 let mut changed = true;
                 while changed {
                     for i in 0..args.len() {
-                        if let Expr::Expression { op, args, name: _ } = &mut args[i] {
-                            if op[0] == Operator::Other("".to_string())
-                                && all_ops_are_mult_or_div(op.to_vec())
+                        if let Expr::Expression { ops, args, name: _ } = &mut args[i] {
+                            if ops[0] == Operator::Other("".to_string())
+                                && all_ops_are_mult_or_div(ops.to_vec())
                             {
                                 args_copy[i] = args[0].clone();
-                                for j in 1..op.len() {
-                                    op_copy.insert(i + shift + j, op[j].clone());
+                                for j in 1..ops.len() {
+                                    op_copy.insert(i + shift + j, ops[j].clone());
                                     args_copy.insert(i + shift + j, args[j].clone());
                                 }
-                                shift = shift + op.len() - 1;
+                                shift = shift + ops.len() - 1;
                             }
                         }
                     }
-                    if op.clone() == op_copy.clone() {
+                    if ops.clone() == op_copy.clone() {
                         changed = false;
                     }
-                    *op = op_copy.clone();
+                    *ops = op_copy.clone();
                     *args = args_copy.clone();
                 }
             }
@@ -330,17 +330,17 @@ impl Expr {
         let mut add_paren = false;
         match self {
             Expr::Atom(_) => "".to_string(),
-            Expr::Expression { op, args, name } => {
-                if op[0] == Operator::Other("".to_string())
-                    && !all_ops_are_mult_or_div(op.to_vec())
+            Expr::Expression { ops, args, name } => {
+                if ops[0] == Operator::Other("".to_string())
+                    && !all_ops_are_mult_or_div(ops.to_vec())
                     && !contains_redundant_parens(name)
                 {
                     name.push('(');
                     add_paren = true;
                 }
-                for i in 0..=op.len() - 1 {
+                for i in 0..=ops.len() - 1 {
                     if i > 0 {
-                        if op[i] == Operator::Equals {
+                        if ops[i] == Operator::Equals {
                             let mut new_name: String = "".to_string();
                             for n in name.as_bytes().clone() {
                                 if *n == 40_u8 {
@@ -352,7 +352,7 @@ impl Expr {
                             }
                             *name = remove_redundant_parens(&mut new_name).clone();
                         } else {
-                            name.push_str(&op[i].to_string().clone());
+                            name.push_str(&ops[i].to_string().clone());
                         }
                     }
                     match &mut args[i] {
@@ -365,10 +365,10 @@ impl Expr {
                             }
                             Atom::Operator(_) => {}
                         },
-                        Expr::Expression { op, .. } => {
+                        Expr::Expression { ops, .. } => {
                             let mut string;
-                            if op[0] != Operator::Other("".to_string()) {
-                                string = op[0].to_string();
+                            if ops[0] != Operator::Other("".to_string()) {
+                                string = ops[0].to_string();
                                 string.push('(');
                                 string.push_str(args[i].set_name().as_str().clone());
                                 string.push(')');
@@ -390,7 +390,7 @@ impl Expr {
     }
 
     fn to_graph(&mut self, graph: &mut MathExpressionGraph) {
-        if let Expr::Expression { op, args, name } = self {
+        if let Expr::Expression { ops, args, name } = self {
             if name == "place_holder" {
                 return;
             } else if name.contains("place_holder") {
@@ -398,12 +398,12 @@ impl Expr {
             }
 
             let mut parent_node_index: NodeIndex = Default::default();
-            if op[0].to_string() != "derivative" {
+            if ops[0].to_string() != "derivative" {
                 parent_node_index = get_node_idx(graph, name)
             }
             let mut eq_loc = 0;
-            if op.contains(&Operator::Equals) {
-                eq_loc = op.iter().position(|r| r == &(Operator::Equals)).unwrap();
+            if ops.contains(&Operator::Equals) {
+                eq_loc = ops.iter().position(|r| r == &(Operator::Equals)).unwrap();
                 let mut left_eq_name: String = "".to_string();
                 for i in 0..eq_loc {
                     match &mut args[i] {
@@ -416,9 +416,9 @@ impl Expr {
                             }
                             Atom::Operator(_y) => {}
                         },
-                        Expr::Expression { op, args: _, name } => {
-                            if op[0] != Operator::Other("".to_string()) {
-                                let mut unitary_name = op[0].to_string();
+                        Expr::Expression { ops, args: _, name } => {
+                            if ops[0] != Operator::Other("".to_string()) {
+                                let mut unitary_name = ops[0].to_string();
                                 let mut name_copy = name.to_string();
                                 remove_redundant_parens(&mut name_copy);
                                 unitary_name.push_str("(".clone());
@@ -435,21 +435,21 @@ impl Expr {
                 let node_idx = get_node_idx(graph, &mut left_eq_name);
                 graph.update_edge(node_idx, parent_node_index, "=".to_string());
             }
-            if op[0] != Operator::Other("".to_string()) {
-                let mut unitary_name = op[0].to_string();
+            if ops[0] != Operator::Other("".to_string()) {
+                let mut unitary_name = ops[0].to_string();
                 let mut name_copy = name.to_string();
                 remove_redundant_parens(&mut name_copy);
                 unitary_name.push_str("(".clone());
                 unitary_name.push_str(&name_copy.clone());
                 unitary_name.push_str(")".clone());
                 let node_idx = get_node_idx(graph, &mut unitary_name);
-                if op[0].to_string() == "derivative" {
+                if ops[0].to_string() == "derivative" {
                     return;
                 } else {
-                    graph.update_edge(parent_node_index, node_idx, op[0].to_string());
+                    graph.update_edge(parent_node_index, node_idx, ops[0].to_string());
                 }
             }
-            let op_copy = op.clone();
+            let op_copy = ops.clone();
             for i in eq_loc..=op_copy.len() - 1 {
                 match &mut args[i] {
                     Expr::Atom(x) => match x {
@@ -593,13 +593,13 @@ impl Expr {
                         }
                         Atom::Operator(_x) => {}
                     },
-                    Expr::Expression { op, name, .. } => {
+                    Expr::Expression { ops, name, .. } => {
                         if name == "place_holder" {
                             continue;
                         } else if name.contains("place_holder") {
                             *name = name.replace("place_holder", "");
                         }
-                        if op[0] == Operator::Other("".to_string()) {
+                        if ops[0] == Operator::Other("".to_string()) {
                             let node_idx = get_node_idx(graph, name);
                             if i == 0 {
                                 if op_copy.len() > 1 {
@@ -663,7 +663,7 @@ impl Expr {
                                 );
                             }
                         } else {
-                            let mut unitary_name = op[0].to_string();
+                            let mut unitary_name = ops[0].to_string();
                             let mut name_copy = name.to_string().clone();
                             remove_redundant_parens(&mut name_copy);
                             unitary_name.push_str("(".clone());
@@ -763,9 +763,9 @@ pub fn contains_redundant_parens(string: &str) -> bool {
 }
 
 /// Check if the current term's operators are all multiply or divide.
-pub fn all_ops_are_mult_or_div(op: Vec<Operator>) -> bool {
-    for o in 1..=op.len() - 1 {
-        if op[o] != Operator::Multiply && op[o] != Operator::Divide {
+pub fn all_ops_are_mult_or_div(ops: Vec<Operator>) -> bool {
+    for o in 1..=ops.len() - 1 {
+        if ops[o] != Operator::Multiply && ops[o] != Operator::Divide {
             return false;
         }
     }
@@ -966,16 +966,16 @@ fn test_to_expr() {
         Mi("b".to_string()),
     ]);
     let mut pre_exp = PreExp {
-        op: Vec::<Operator>::new(),
+        ops: Vec::<Operator>::new(),
         args: Vec::<Expr>::new(),
         name: "".to_string(),
     };
-    pre_exp.op.push(Operator::Other("root".to_string()));
+    pre_exp.ops.push(Operator::Other("root".to_string()));
     math_expression.to_expr(&mut pre_exp);
 
-    if let Expr::Expression { op, args, .. } = &pre_exp.args[0] {
-        assert_eq!(op[0], Operator::Other("".to_string()));
-        assert_eq!(op[1], Operator::Add);
+    if let Expr::Expression { ops, args, .. } = &pre_exp.args[0] {
+        assert_eq!(ops[0], Operator::Other("".to_string()));
+        assert_eq!(ops[1], Operator::Add);
         assert_eq!(args[0], Expr::Atom(Atom::Identifier("a".to_string())));
         assert_eq!(args[1], Expr::Atom(Atom::Identifier("b".to_string())));
     }
@@ -995,27 +995,27 @@ fn test_to_expr2() {
         ]),
     ]);
     let mut pre_exp = PreExp {
-        op: Vec::<Operator>::new(),
+        ops: Vec::<Operator>::new(),
         args: Vec::<Expr>::new(),
         name: "".to_string(),
     };
 
     math_expression.to_expr(&mut pre_exp);
-    pre_exp.op.push(Operator::Other("root".to_string()));
+    pre_exp.ops.push(Operator::Other("root".to_string()));
     match &pre_exp.args[0] {
         Expr::Atom(_) => {}
-        Expr::Expression { op, args, .. } => {
-            assert_eq!(op[0], Operator::Other("".to_string()));
-            assert_eq!(op[1], Operator::Add);
-            assert_eq!(op[2], Operator::Subtract);
+        Expr::Expression { ops, args, .. } => {
+            assert_eq!(ops[0], Operator::Other("".to_string()));
+            assert_eq!(ops[1], Operator::Add);
+            assert_eq!(ops[2], Operator::Subtract);
             assert_eq!(args[0], Expr::Atom(Atom::Identifier("a".to_string())));
             assert_eq!(args[1], Expr::Atom(Atom::Identifier("b".to_string())));
             match &args[2] {
                 Expr::Atom(_) => {}
-                Expr::Expression { op, args, .. } => {
-                    assert_eq!(op[0], Operator::Other("".to_string()));
-                    assert_eq!(op[1], Operator::Multiply);
-                    assert_eq!(op[2], Operator::Multiply);
+                Expr::Expression { ops, args, .. } => {
+                    assert_eq!(ops[0], Operator::Other("".to_string()));
+                    assert_eq!(ops[1], Operator::Multiply);
+                    assert_eq!(ops[2], Operator::Multiply);
                     assert_eq!(args[0], Expr::Atom(Atom::Number("4".to_string())));
                     assert_eq!(args[1], Expr::Atom(Atom::Identifier("c".to_string())));
                     assert_eq!(args[2], Expr::Atom(Atom::Identifier("d".to_string())));
@@ -1033,22 +1033,22 @@ fn test_to_expr3() {
         Mi("b".to_string()),
     ])));
     let mut pre_exp = PreExp {
-        op: Vec::<Operator>::new(),
+        ops: Vec::<Operator>::new(),
         args: Vec::<Expr>::new(),
         name: "".to_string(),
     };
-    pre_exp.op.push(Operator::Other("root".to_string()));
+    pre_exp.ops.push(Operator::Other("root".to_string()));
     math_expression.to_expr(&mut pre_exp);
 
     match &pre_exp.args[0] {
         Expr::Atom(_) => {}
-        Expr::Expression { op, args, .. } => {
-            assert_eq!(op[0], Operator::Sqrt);
+        Expr::Expression { ops, args, .. } => {
+            assert_eq!(ops[0], Operator::Sqrt);
             match &args[0] {
                 Expr::Atom(_) => {}
-                Expr::Expression { op, args, .. } => {
-                    assert_eq!(op[0], Operator::Other("".to_string()));
-                    assert_eq!(op[1], Operator::Add);
+                Expr::Expression { ops, args, .. } => {
+                    assert_eq!(ops[0], Operator::Other("".to_string()));
+                    assert_eq!(ops[1], Operator::Add);
                     assert_eq!(args[0], Expr::Atom(Atom::Identifier("a".to_string())));
                     assert_eq!(args[1], Expr::Atom(Atom::Identifier("b".to_string())));
                 }
@@ -1068,23 +1068,23 @@ fn test_to_expr4() {
         Box::from(Mi("c".to_string())),
     );
     let mut pre_exp = PreExp {
-        op: Vec::<Operator>::new(),
+        ops: Vec::<Operator>::new(),
         args: Vec::<Expr>::new(),
         name: "".to_string(),
     };
-    pre_exp.op.push(Operator::Other("root".to_string()));
+    pre_exp.ops.push(Operator::Other("root".to_string()));
     math_expression.to_expr(&mut pre_exp);
 
     match &pre_exp.args[0] {
         Expr::Atom(_) => {}
-        Expr::Expression { op, args, .. } => {
-            assert_eq!(op[0], Operator::Other("".to_string()));
-            assert_eq!(op[1], Operator::Divide);
+        Expr::Expression { ops, args, .. } => {
+            assert_eq!(ops[0], Operator::Other("".to_string()));
+            assert_eq!(ops[1], Operator::Divide);
             match &args[0] {
                 Expr::Atom(_) => {}
-                Expr::Expression { op, args, .. } => {
-                    assert_eq!(op[0], Operator::Other("".to_string()));
-                    assert_eq!(op[1], Operator::Add);
+                Expr::Expression { ops, args, .. } => {
+                    assert_eq!(ops[0], Operator::Other("".to_string()));
+                    assert_eq!(ops[1], Operator::Add);
                     assert_eq!(args[0], Expr::Atom(Atom::Identifier("a".to_string())));
                     assert_eq!(args[1], Expr::Atom(Atom::Identifier("b".to_string())));
                 }
@@ -1109,25 +1109,25 @@ fn test_to_expr5() {
         Mi("c".to_string()),
     ]);
     let mut pre_exp = PreExp {
-        op: Vec::<Operator>::new(),
+        ops: Vec::<Operator>::new(),
         args: Vec::<Expr>::new(),
         name: "".to_string(),
     };
-    pre_exp.op.push(Operator::Other("root".to_string()));
+    pre_exp.ops.push(Operator::Other("root".to_string()));
     math_expression.to_expr(&mut pre_exp);
     pre_exp.group_expr();
 
     match &pre_exp.args[0] {
         Expr::Atom(_) => {}
-        Expr::Expression { op, args, .. } => {
-            assert_eq!(op[0], Operator::Other("".to_string()));
-            assert_eq!(op[1], Operator::Add);
+        Expr::Expression { ops, args, .. } => {
+            assert_eq!(ops[0], Operator::Other("".to_string()));
+            assert_eq!(ops[1], Operator::Add);
             assert_eq!(args[0], Expr::Atom(Atom::Identifier("a".to_string())));
             match &args[1] {
                 Expr::Atom(_) => {}
-                Expr::Expression { op, args, .. } => {
-                    assert_eq!(op[0], Operator::Other("".to_string()));
-                    assert_eq!(op[1], Operator::Multiply);
+                Expr::Expression { ops, args, .. } => {
+                    assert_eq!(ops[0], Operator::Other("".to_string()));
+                    assert_eq!(ops[1], Operator::Multiply);
                     assert_eq!(args[0], Expr::Atom(Atom::Identifier("b".to_string())));
                     assert_eq!(args[1], Expr::Atom(Atom::Identifier("c".to_string())));
                 }
@@ -1156,29 +1156,29 @@ fn test_to_expr6() {
         Mi("h".to_string()),
     ]);
     let mut pre_exp = PreExp {
-        op: Vec::<Operator>::new(),
+        ops: Vec::<Operator>::new(),
         args: Vec::<Expr>::new(),
         name: "".to_string(),
     };
-    pre_exp.op.push(Operator::Other("root".to_string()));
+    pre_exp.ops.push(Operator::Other("root".to_string()));
     math_expression.to_expr(&mut pre_exp);
     pre_exp.group_expr();
 
     match &pre_exp.args[0] {
         Expr::Atom(_) => {}
-        Expr::Expression { op, args, .. } => {
-            assert_eq!(op[0], Operator::Other("".to_string()));
-            assert_eq!(op[1], Operator::Add);
-            assert_eq!(op[2], Operator::Subtract);
+        Expr::Expression { ops, args, .. } => {
+            assert_eq!(ops[0], Operator::Other("".to_string()));
+            assert_eq!(ops[1], Operator::Add);
+            assert_eq!(ops[2], Operator::Subtract);
             assert_eq!(args[0], Expr::Atom(Atom::Identifier("a".to_string())));
             assert_eq!(args[3], Expr::Atom(Atom::Identifier("h".to_string())));
             match &args[1] {
                 Expr::Atom(_) => {}
-                Expr::Expression { op, args, .. } => {
-                    assert_eq!(op[0], Operator::Other("".to_string()));
-                    assert_eq!(op[1], Operator::Multiply);
-                    assert_eq!(op[2], Operator::Multiply);
-                    assert_eq!(op[3], Operator::Divide);
+                Expr::Expression { ops, args, .. } => {
+                    assert_eq!(ops[0], Operator::Other("".to_string()));
+                    assert_eq!(ops[1], Operator::Multiply);
+                    assert_eq!(ops[2], Operator::Multiply);
+                    assert_eq!(ops[3], Operator::Divide);
                     assert_eq!(args[0], Expr::Atom(Atom::Identifier("b".to_string())));
                     assert_eq!(args[1], Expr::Atom(Atom::Identifier("c".to_string())));
                     assert_eq!(args[2], Expr::Atom(Atom::Identifier("d".to_string())));
@@ -1187,9 +1187,9 @@ fn test_to_expr6() {
             }
             match &args[2] {
                 Expr::Atom(_) => {}
-                Expr::Expression { op, args, .. } => {
-                    assert_eq!(op[0], Operator::Other("".to_string()));
-                    assert_eq!(op[1], Operator::Multiply);
+                Expr::Expression { ops, args, .. } => {
+                    assert_eq!(ops[0], Operator::Other("".to_string()));
+                    assert_eq!(ops[1], Operator::Multiply);
                     assert_eq!(args[0], Expr::Atom(Atom::Identifier("f".to_string())));
                     assert_eq!(args[1], Expr::Atom(Atom::Identifier("g".to_string())));
                 }
@@ -1208,27 +1208,27 @@ fn test_to_expr7() {
         Mi("c".to_string()),
     ]);
     let mut pre_exp = PreExp {
-        op: Vec::<Operator>::new(),
+        ops: Vec::<Operator>::new(),
         args: Vec::<Expr>::new(),
         name: "root".to_string(),
     };
-    pre_exp.op.push(Operator::Other("root".to_string()));
+    pre_exp.ops.push(Operator::Other("root".to_string()));
     math_expression.to_expr(&mut pre_exp);
     pre_exp.group_expr();
     pre_exp.set_name();
 
     match &pre_exp.args[0] {
         Expr::Atom(_) => {}
-        Expr::Expression { op, args, name } => {
-            assert_eq!(op[0], Operator::Other("".to_string()));
-            assert_eq!(op[1], Operator::Add);
+        Expr::Expression { ops, args, name } => {
+            assert_eq!(ops[0], Operator::Other("".to_string()));
+            assert_eq!(ops[1], Operator::Add);
             assert_eq!(args[0], Expr::Atom(Atom::Identifier("a".to_string())));
             assert_eq!(name, "(a+b*c)");
             match &args[1] {
                 Expr::Atom(_) => {}
-                Expr::Expression { op, args, name } => {
-                    assert_eq!(op[0], Operator::Other("".to_string()));
-                    assert_eq!(op[1], Operator::Multiply);
+                Expr::Expression { ops, args, name } => {
+                    assert_eq!(ops[0], Operator::Other("".to_string()));
+                    assert_eq!(ops[1], Operator::Multiply);
                     assert_eq!(args[0], Expr::Atom(Atom::Identifier("b".to_string())));
                     assert_eq!(args[1], Expr::Atom(Atom::Identifier("c".to_string())));
                     assert_eq!(name, "b*c");
@@ -1258,31 +1258,31 @@ fn test_to_expr8() {
         Mi("h".to_string()),
     ]);
     let mut pre_exp = PreExp {
-        op: Vec::<Operator>::new(),
+        ops: Vec::<Operator>::new(),
         args: Vec::<Expr>::new(),
         name: "".to_string(),
     };
-    pre_exp.op.push(Operator::Other("root".to_string()));
+    pre_exp.ops.push(Operator::Other("root".to_string()));
     math_expression.to_expr(&mut pre_exp);
     pre_exp.group_expr();
     pre_exp.set_name();
 
     match &pre_exp.args[0] {
         Expr::Atom(_) => {}
-        Expr::Expression { op, args, name } => {
-            assert_eq!(op[0], Operator::Other("".to_string()));
-            assert_eq!(op[1], Operator::Add);
-            assert_eq!(op[2], Operator::Subtract);
+        Expr::Expression { ops, args, name } => {
+            assert_eq!(ops[0], Operator::Other("".to_string()));
+            assert_eq!(ops[1], Operator::Add);
+            assert_eq!(ops[2], Operator::Subtract);
             assert_eq!(args[0], Expr::Atom(Atom::Identifier("a".to_string())));
             assert_eq!(args[3], Expr::Atom(Atom::Identifier("h".to_string())));
             assert_eq!(name, "(a+b*c*d/e-f*g-h)");
             match &args[1] {
                 Expr::Atom(_) => {}
-                Expr::Expression { op, args, name } => {
-                    assert_eq!(op[0], Operator::Other("".to_string()));
-                    assert_eq!(op[1], Operator::Multiply);
-                    assert_eq!(op[2], Operator::Multiply);
-                    assert_eq!(op[3], Operator::Divide);
+                Expr::Expression { ops, args, name } => {
+                    assert_eq!(ops[0], Operator::Other("".to_string()));
+                    assert_eq!(ops[1], Operator::Multiply);
+                    assert_eq!(ops[2], Operator::Multiply);
+                    assert_eq!(ops[3], Operator::Divide);
                     assert_eq!(args[0], Expr::Atom(Atom::Identifier("b".to_string())));
                     assert_eq!(args[1], Expr::Atom(Atom::Identifier("c".to_string())));
                     assert_eq!(args[2], Expr::Atom(Atom::Identifier("d".to_string())));
@@ -1292,9 +1292,9 @@ fn test_to_expr8() {
             }
             match &args[2] {
                 Expr::Atom(_) => {}
-                Expr::Expression { op, args, name } => {
-                    assert_eq!(op[0], Operator::Other("".to_string()));
-                    assert_eq!(op[1], Operator::Multiply);
+                Expr::Expression { ops, args, name } => {
+                    assert_eq!(ops[0], Operator::Other("".to_string()));
+                    assert_eq!(ops[1], Operator::Multiply);
                     assert_eq!(args[0], Expr::Atom(Atom::Identifier("f".to_string())));
                     assert_eq!(args[1], Expr::Atom(Atom::Identifier("g".to_string())));
                     assert_eq!(name, "f*g");
@@ -1318,34 +1318,34 @@ fn test_to_expr9() {
         ]),
     ]);
     let mut pre_exp = PreExp {
-        op: Vec::<Operator>::new(),
+        ops: Vec::<Operator>::new(),
         args: Vec::<Expr>::new(),
         name: "root".to_string(),
     };
-    pre_exp.op.push(Operator::Other("root".to_string()));
+    pre_exp.ops.push(Operator::Other("root".to_string()));
     math_expression.to_expr(&mut pre_exp);
     pre_exp.group_expr();
     pre_exp.set_name();
 
     match &pre_exp.args[0] {
         Expr::Atom(_) => {}
-        Expr::Expression { op, args, name } => {
-            assert_eq!(op[0], Operator::Other("".to_string()));
-            assert_eq!(op[1], Operator::Add);
+        Expr::Expression { ops, args, name } => {
+            assert_eq!(ops[0], Operator::Other("".to_string()));
+            assert_eq!(ops[1], Operator::Add);
             assert_eq!(args[0], Expr::Atom(Atom::Identifier("a".to_string())));
             assert_eq!(name, "(a+b*(c-d))");
             match &args[1] {
                 Expr::Atom(_) => {}
-                Expr::Expression { op, args, name } => {
-                    assert_eq!(op[0], Operator::Other("".to_string()));
-                    assert_eq!(op[1], Operator::Multiply);
+                Expr::Expression { ops, args, name } => {
+                    assert_eq!(ops[0], Operator::Other("".to_string()));
+                    assert_eq!(ops[1], Operator::Multiply);
                     assert_eq!(args[0], Expr::Atom(Atom::Identifier("b".to_string())));
                     assert_eq!(name, "b*(c-d)");
                     match &args[1] {
                         Expr::Atom(_) => {}
-                        Expr::Expression { op, args, name } => {
-                            assert_eq!(op[0], Operator::Other("".to_string()));
-                            assert_eq!(op[1], Operator::Subtract);
+                        Expr::Expression { ops, args, name } => {
+                            assert_eq!(ops[0], Operator::Other("".to_string()));
+                            assert_eq!(ops[1], Operator::Subtract);
                             assert_eq!(args[0], Expr::Atom(Atom::Identifier("c".to_string())));
                             assert_eq!(args[1], Expr::Atom(Atom::Identifier("d".to_string())));
                             assert_eq!(name, "(c-d)");
@@ -1371,11 +1371,11 @@ fn test_to_expr10() {
         ]),
     ]);
     let mut pre_exp = PreExp {
-        op: Vec::<Operator>::new(),
+        ops: Vec::<Operator>::new(),
         args: Vec::<Expr>::new(),
         name: "root".to_string(),
     };
-    pre_exp.op.push(Operator::Other("root".to_string()));
+    pre_exp.ops.push(Operator::Other("root".to_string()));
     math_expression.to_expr(&mut pre_exp);
     pre_exp.group_expr();
     pre_exp.set_name();
@@ -1397,11 +1397,11 @@ fn test_to_expr11() {
     ])));
 
     let mut pre_exp = PreExp {
-        op: Vec::<Operator>::new(),
+        ops: Vec::<Operator>::new(),
         args: Vec::<Expr>::new(),
         name: "root".to_string(),
     };
-    pre_exp.op.push(Operator::Other("root".to_string()));
+    pre_exp.ops.push(Operator::Other("root".to_string()));
     math_expression.to_expr(&mut pre_exp);
     pre_exp.group_expr();
     pre_exp.set_name();
@@ -1428,11 +1428,11 @@ fn test_to_expr12() {
         Mi("h".to_string()),
     ]);
     let mut pre_exp = PreExp {
-        op: Vec::<Operator>::new(),
+        ops: Vec::<Operator>::new(),
         args: Vec::<Expr>::new(),
         name: "".to_string(),
     };
-    pre_exp.op.push(Operator::Other("root".to_string()));
+    pre_exp.ops.push(Operator::Other("root".to_string()));
     math_expression.to_expr(&mut pre_exp);
     pre_exp.group_expr();
     pre_exp.set_name();
@@ -1459,11 +1459,11 @@ fn test_to_expr13() {
         Mi("b".to_string()),
     ]);
     let mut pre_exp = PreExp {
-        op: Vec::<Operator>::new(),
+        ops: Vec::<Operator>::new(),
         args: Vec::<Expr>::new(),
         name: "".to_string(),
     };
-    pre_exp.op.push(Operator::Other("root".to_string()));
+    pre_exp.ops.push(Operator::Other("root".to_string()));
     math_expression.to_expr(&mut pre_exp);
     pre_exp.group_expr();
     pre_exp.set_name();
@@ -1486,11 +1486,11 @@ fn test_to_expr14() {
         ]),
     ]);
     let mut pre_exp = PreExp {
-        op: Vec::<Operator>::new(),
+        ops: Vec::<Operator>::new(),
         args: Vec::<Expr>::new(),
         name: "".to_string(),
     };
-    pre_exp.op.push(Operator::Other("root".to_string()));
+    pre_exp.ops.push(Operator::Other("root".to_string()));
     math_expression.to_expr(&mut pre_exp);
     pre_exp.group_expr();
     pre_exp.set_name();
@@ -1513,11 +1513,11 @@ fn test_to_expr15() {
         ]))),
     ]);
     let mut pre_exp = PreExp {
-        op: Vec::<Operator>::new(),
+        ops: Vec::<Operator>::new(),
         args: Vec::<Expr>::new(),
         name: "".to_string(),
     };
-    pre_exp.op.push(Operator::Other("root".to_string()));
+    pre_exp.ops.push(Operator::Other("root".to_string()));
     math_expression.to_expr(&mut pre_exp);
     pre_exp.group_expr();
     pre_exp.set_name();
@@ -1630,23 +1630,23 @@ fn test_to_expr21() {
         Box::from(Mi("c".to_string())),
     );
     let mut pre_exp = PreExp {
-        op: Vec::<Operator>::new(),
+        ops: Vec::<Operator>::new(),
         args: Vec::<Expr>::new(),
         name: "".to_string(),
     };
-    pre_exp.op.push(Operator::Other("root".to_string()));
+    pre_exp.ops.push(Operator::Other("root".to_string()));
     math_expression.to_expr(&mut pre_exp);
 
     match &pre_exp.args[0] {
         Expr::Atom(_) => {}
-        Expr::Expression { op, args, .. } => {
-            assert_eq!(op[0], Operator::Other("".to_string()));
-            assert_eq!(op[1], Operator::Other("^".to_string()));
+        Expr::Expression { ops, args, .. } => {
+            assert_eq!(ops[0], Operator::Other("".to_string()));
+            assert_eq!(ops[1], Operator::Other("^".to_string()));
             match &args[0] {
                 Expr::Atom(_) => {}
-                Expr::Expression { op, args, .. } => {
-                    assert_eq!(op[0], Operator::Other("".to_string()));
-                    assert_eq!(op[1], Operator::Add);
+                Expr::Expression { ops, args, .. } => {
+                    assert_eq!(ops[0], Operator::Other("".to_string()));
+                    assert_eq!(ops[1], Operator::Add);
                     assert_eq!(args[0], Expr::Atom(Atom::Identifier("a".to_string())));
                     assert_eq!(args[1], Expr::Atom(Atom::Identifier("b".to_string())));
                 }


### PR DESCRIPTION
This PR renames the 'op' field to 'ops' in the PreExp and Expression structs, to better reflect that the fields represent vectors of operators rather than single operators.