### PR TITLE
Fixing docker-compose.skema-rs.yml

### DIFF
--- a/docker-compose.skema-rs.yml
+++ b/docker-compose.skema-rs.yml
@@ -3,7 +3,9 @@ version: "3"
 services:
   # The skema-rs web service exposing functionality implemented in Rust.
   skema-rs:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile.skema-rs
     entrypoint: cargo run --release --bin skema_service -- --host 0.0.0.0 --db-host database
     ports:
       - "8080:8080"


### PR DESCRIPTION
This PR fixes `docker-compose.skema-rs.yml` to have the correct build context and Dockerfile.