### PR TITLE
Plain text entry point

### DIFF
--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/PlainTextFileTextReadingPipeline.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/PlainTextFileTextReadingPipeline.scala
@@ -1,0 +1,51 @@
+package org.ml4ai.skema.text_reading
+
+import org.clulab.odin.Mention
+import org.ml4ai.skema.text_reading.scenario_context.{ContextEngine, CosmosOrderer, SentenceIndexOrderer}
+import org.ml4ai.skema.text_reading.serializer.SkemaJSONSerializer
+
+import java.io.File
+import scala.io.Source
+import scala.util.{Failure, Success, Using}
+
+class PlainTextFileTextReadingPipeline(contextWindowSize:Int) extends TextReadingPipeline {
+
+  /**
+    * Runs the textReadingPipeline over a plain text file
+    *
+    * @param filePath Path to the text file to annotate
+    * @return Mentions extracted by the TR textReadingPipeline
+    */
+  def extractMentionsFromTextFile(filePath:String):Seq[Mention] = {
+    val fileContents =
+      Using(Source.fromFile(filePath)){
+        source =>
+          source.mkString
+      }
+
+    fileContents match {
+      case Success(text) =>
+        logger.info(s"Starting annotation of $filePath")
+        val fileName = new File(filePath).getName
+        val mentions = this.extractMentions(text, Some(fileName))._2  // TODO Make this a case class for legibility
+
+        // Resolve scenario context
+        val scenarioContextEngine = new ContextEngine(windowSize = contextWindowSize, mentions, SentenceIndexOrderer)
+        val mentionsWithScenarioContext = mentions map scenarioContextEngine.resolveContext
+        logger.info(s"Finished annotation of $filePath")
+        mentionsWithScenarioContext
+      case Failure(exception) =>
+        logger.error(s"Failed to read the contents of $filePath\t-\t$exception")
+        Seq.empty
+    }
+  }
+
+  /**
+    * Extracts the mentions and serializes them into a json string
+    *
+    * @param filePath Path to the plain text file to annotate
+    * @return string with the json representation of the extractions and the document annotations
+    */
+  def extractMentionsFromTextFileAndSerialize(filePath:String): String = ujson.write(SkemaJSONSerializer.serializeMentions(this.extractMentionsFromTextFile(filePath)))
+
+}

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/TextReadingPipelineWithContext.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/TextReadingPipelineWithContext.scala
@@ -2,6 +2,7 @@ package org.ml4ai.skema.text_reading
 
 import org.clulab.odin.Mention
 import org.ml4ai.skema.text_reading.scenario_context.{ContextEngine, SentenceIndexOrderer}
+import org.ml4ai.skema.text_reading.serializer.SkemaJSONSerializer
 
 /**
   * Runs extraction, grounding and context on input string objects
@@ -21,5 +22,13 @@ class TextReadingPipelineWithContext(contextWindowSize:Int) extends TextReadingP
     val mentionsWithScenarioContext = mentions map scenarioContextEngine.resolveContext
     mentionsWithScenarioContext
   }
+
+  /**
+    * Extracts the mentions and serializes them into a json string
+    *
+    * @param inputText Text to annotate
+    * @return string with the json representation of the extractions and the document annotations
+    */
+  def extractMentionsWithContextAndSerialize(inputText: String): String = ujson.write(SkemaJSONSerializer.serializeMentions(this.extractMentionsWithContext(inputText)))
 
 }

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/TextReadingPipelineWithContext.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/TextReadingPipelineWithContext.scala
@@ -7,19 +7,19 @@ import org.ml4ai.skema.text_reading.serializer.SkemaJSONSerializer
 /**
   * Runs extraction, grounding and context on input string objects
   */
-class TextReadingPipelineWithContext(contextWindowSize:Int) extends TextReadingPipeline{
+class TextReadingPipelineWithContext() extends TextReadingPipeline {
 
   /**
     * Extracts mentions and runs the context engine over the extractions
     * @param inputText text to annotate
+    * @param contextWindowSize Size of the context window
     * @return extractions with scenario context
     */
-  def extractMentionsWithContext(inputText:String):Seq[Mention] ={
-    val mentions = this.extractMentions(inputText, None)._2
+  def extractMentionsWithContext(inputText: String, contextWindowSize: Int): Seq[Mention] = {
+    val mentions = extractMentions(inputText, None)._2
+    val scenarioContextEngine = new ContextEngine(contextWindowSize, mentions, SentenceIndexOrderer)
+    val mentionsWithScenarioContext = mentions.map(scenarioContextEngine.resolveContext)
 
-    // Resolve scenario context
-    val scenarioContextEngine = new ContextEngine(windowSize = contextWindowSize, mentions, SentenceIndexOrderer)
-    val mentionsWithScenarioContext = mentions map scenarioContextEngine.resolveContext
     mentionsWithScenarioContext
   }
 
@@ -27,8 +27,13 @@ class TextReadingPipelineWithContext(contextWindowSize:Int) extends TextReadingP
     * Extracts the mentions and serializes them into a json string
     *
     * @param inputText Text to annotate
+    * @param contextWindowSize Size of the context window
     * @return string with the json representation of the extractions and the document annotations
     */
-  def extractMentionsWithContextAndSerialize(inputText: String): String = ujson.write(SkemaJSONSerializer.serializeMentions(this.extractMentionsWithContext(inputText)))
+  def extractMentionsWithContextAndSerialize(inputText: String, contextWindowSize: Int): String = {
+    val mentions = extractMentionsWithContext(inputText, contextWindowSize)
+    val json = ujson.write(SkemaJSONSerializer.serializeMentions(mentions))
 
+    json
+  }
 }

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/TextReadingPipelineWithContext.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/TextReadingPipelineWithContext.scala
@@ -1,0 +1,25 @@
+package org.ml4ai.skema.text_reading
+
+import org.clulab.odin.Mention
+import org.ml4ai.skema.text_reading.scenario_context.{ContextEngine, SentenceIndexOrderer}
+
+/**
+  * Runs extraction, grounding and context on input string objects
+  */
+class TextReadingPipelineWithContext(contextWindowSize:Int) extends TextReadingPipeline{
+
+  /**
+    * Extracts mentions and runs the context engine over the extractions
+    * @param inputText text to annotate
+    * @return extractions with scenario context
+    */
+  def extractMentionsWithContext(inputText:String):Seq[Mention] ={
+    val mentions = this.extractMentions(inputText, None)._2
+
+    // Resolve scenario context
+    val scenarioContextEngine = new ContextEngine(windowSize = contextWindowSize, mentions, SentenceIndexOrderer)
+    val mentionsWithScenarioContext = mentions map scenarioContextEngine.resolveContext
+    mentionsWithScenarioContext
+  }
+
+}

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/apps/AnnotateCosmosJsonFiles.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/apps/AnnotateCosmosJsonFiles.scala
@@ -1,6 +1,6 @@
 package org.ml4ai.skema.text_reading.apps
 
-import org.clulab.utils.Logging
+import org.clulab.utils.{FileUtils, Logging}
 import org.ml4ai.skema.text_reading.CosmosTextReadingPipeline
 import org.ml4ai.skema.text_reading.utils.{ArgsConfig, CommandLineArgumentParser}
 
@@ -12,7 +12,7 @@ import java.io.{File, FileOutputStream, PrintWriter}
 
 object AnnotateCosmosJsonFiles extends App with Logging{
 
-  val parser = CommandLineArgumentParser.buildParser("AnnotateCosmosJsonFiles")
+  val parser = CommandLineArgumentParser.buildParser(getClass.getSimpleName.dropRight(1))
 
   OParser.parse(parser, args, ArgsConfig()) match {
     case Some(config) =>
@@ -41,11 +41,9 @@ object AnnotateCosmosJsonFiles extends App with Logging{
             val outputFile = new File(config.outDir, "extractions_" + inputFile.getName)
             logger.info(s"Extraction mentions from ${inputFile.getAbsolutePath}")
             val jsonContents = textReadingPipeline.extractMentionsFromJsonAndSerialize(inputFile.getAbsolutePath)
-            Using(new PrintWriter(new FileOutputStream(outputFile))) {
-              writer =>
-                writer.write(jsonContents)
-                writer.close()
-                logger.info(s"Wrote output to ${outputFile.getAbsolutePath}")
+            Using(FileUtils.printWriterFromFile(outputFile)) { printWriter =>
+              printWriter.println(jsonContents)
+              logger.info(s"Wrote output to ${outputFile.getAbsolutePath}")
             }
           }
           else

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/apps/AnnotatePlainTextFiles.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/apps/AnnotatePlainTextFiles.scala
@@ -1,8 +1,8 @@
 package org.ml4ai.skema.text_reading.apps
 
 import org.clulab.utils.Logging
-import org.ml4ai.skema.text_reading.CosmosTextReadingPipeline
 import org.ml4ai.skema.text_reading.utils.{ArgsConfig, CommandLineArgumentParser}
+import org.ml4ai.skema.text_reading.PlainTextFileTextReadingPipeline
 
 import scala.util.Using
 import scopt.OParser
@@ -10,13 +10,13 @@ import scopt.OParser
 import java.io.{File, FileOutputStream, PrintWriter}
 
 
-object AnnotateCosmosJsonFiles extends App with Logging{
+object AnnotatePlainTextFiles extends App with Logging{
 
-  val parser = CommandLineArgumentParser.buildParser("AnnotateCosmosJsonFiles")
+  val parser = CommandLineArgumentParser.buildParser("AnnotatePlainTextFiles")
 
   OParser.parse(parser, args, ArgsConfig()) match {
     case Some(config) =>
-      val textReadingPipeline = new CosmosTextReadingPipeline(contextWindowSize = 3) // TODO Add the window parameter to the configuration file
+      val textReadingPipeline = new PlainTextFileTextReadingPipeline(contextWindowSize = 3) // TODO Add the window parameter to the configuration file
 
       logger.info(s"Starting process with ${config.inputFiles} arguments")
 
@@ -28,19 +28,18 @@ object AnnotateCosmosJsonFiles extends App with Logging{
           else
             Seq(p)
         }
-
       }
 
       for{
         inputFile <- pathsToAnnotate.par
-        if inputFile.getName.endsWith(".json")
+        if inputFile.getName.endsWith(".txt")
       } {
 
         try {
           if(inputFile.exists()){
             val outputFile = new File(config.outDir, "extractions_" + inputFile.getName)
             logger.info(s"Extraction mentions from ${inputFile.getAbsolutePath}")
-            val jsonContents = textReadingPipeline.extractMentionsFromJsonAndSerialize(inputFile.getAbsolutePath)
+            val jsonContents = textReadingPipeline.extractMentionsFromTextFileAndSerialize(inputFile.getAbsolutePath)
             Using(new PrintWriter(new FileOutputStream(outputFile))) {
               writer =>
                 writer.write(jsonContents)
@@ -59,6 +58,7 @@ object AnnotateCosmosJsonFiles extends App with Logging{
 
       logger.info("Finished")
     case _ =>
-      // arguments are bad, error message will have been displayed
+    // arguments are bad, error message will have been displayed
   }
 }
+

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/apps/AnnotatePlainTextFiles.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/apps/AnnotatePlainTextFiles.scala
@@ -1,18 +1,17 @@
 package org.ml4ai.skema.text_reading.apps
 
-import org.clulab.utils.Logging
-import org.ml4ai.skema.text_reading.utils.{ArgsConfig, CommandLineArgumentParser}
+import org.clulab.utils.{FileUtils, Logging}
 import org.ml4ai.skema.text_reading.PlainTextFileTextReadingPipeline
-
-import scala.util.Using
+import org.ml4ai.skema.text_reading.utils.{ArgsConfig, CommandLineArgumentParser}
 import scopt.OParser
 
-import java.io.{File, FileOutputStream, PrintWriter}
+import java.io.File
+import scala.util.Using
 
 
 object AnnotatePlainTextFiles extends App with Logging{
 
-  val parser = CommandLineArgumentParser.buildParser("AnnotatePlainTextFiles")
+  val parser = CommandLineArgumentParser.buildParser(getClass.getSimpleName.dropRight(1))
 
   OParser.parse(parser, args, ArgsConfig()) match {
     case Some(config) =>
@@ -40,11 +39,9 @@ object AnnotatePlainTextFiles extends App with Logging{
             val outputFile = new File(config.outDir, "extractions_" + inputFile.getName)
             logger.info(s"Extraction mentions from ${inputFile.getAbsolutePath}")
             val jsonContents = textReadingPipeline.extractMentionsFromTextFileAndSerialize(inputFile.getAbsolutePath)
-            Using(new PrintWriter(new FileOutputStream(outputFile))) {
-              writer =>
-                writer.write(jsonContents)
-                writer.close()
-                logger.info(s"Wrote output to ${outputFile.getAbsolutePath}")
+            Using(FileUtils.printWriterFromFile(outputFile)) { printWriter =>
+              printWriter.println(jsonContents)
+              logger.info(s"Wrote output to ${outputFile.getAbsolutePath}")
             }
           }
           else

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/apps/ExtractAndExport.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/apps/ExtractAndExport.scala
@@ -14,7 +14,7 @@ import org.ml4ai.skema.text_reading.attachments.{AutomatesAttachment, MentionLoc
 import org.ml4ai.skema.text_reading.cosmosjson.CosmosJsonProcessor
 import org.ml4ai.skema.text_reading.data.{CosmosJsonDataLoader, DataLoader, TextRouter}
 import org.ml4ai.skema.text_reading.mentions.CrossSentenceEventMention
-import org.ml4ai.skema.text_reading.serializer.AutomatesJSONSerializer
+import org.ml4ai.skema.text_reading.serializer.SkemaJSONSerializer
 import org.ml4ai.skema.text_reading.utils.{DisplayUtils, MentionUtils}
 
 import scala.collection.mutable.ArrayBuffer
@@ -178,7 +178,7 @@ case class JSONExporter(filename: String) extends Exporter {
 
 case class AutomatesExporter(filename: String) extends Exporter {
   override def export(mentions: Seq[Mention]): Unit = {
-    val serialized = ujson.write(AutomatesJSONSerializer.serializeMentions(mentions))
+    val serialized = ujson.write(SkemaJSONSerializer.serializeMentions(mentions))
     //    val groundingsJson4s = json4s.jackson.prettyJson(json4s.jackson.parseJson(serialized))
     val file = new File(filename)
     val bw = new BufferedWriter(new FileWriter(file))

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/serializer/SkemaJSONSerializer.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/serializer/SkemaJSONSerializer.scala
@@ -13,7 +13,7 @@ import org.ml4ai.skema.text_reading.mentions.CrossSentenceEventMention
 import scala.collection.mutable.ArrayBuffer
 import scala.util.hashing.MurmurHash3.{finalizeHash, mix, stringHash, unorderedHash}
 
-object AutomatesJSONSerializer {
+object SkemaJSONSerializer {
 
   // This is a ujson adaptation of org.clulab.odin.serialization.json.JSONSerializer
 
@@ -359,7 +359,7 @@ object AutomatesJSONSerializer {
         "document" -> tb.document.equivalenceHash.toString,
         "keep" -> tb.keep,
         "foundBy" -> tb.foundBy,
-        "attachments" -> AutomatesJSONSerializer.toUJson(tb.attachments)
+        "attachments" -> SkemaJSONSerializer.toUJson(tb.attachments)
       )
     }
   }
@@ -375,7 +375,7 @@ object AutomatesJSONSerializer {
         "text" -> rm.text,
         "labels" -> rm.labels,
         "arguments" -> argsToUJson(rm.arguments),
-        "paths" -> AutomatesJSONSerializer.pathsAsUJson(rm.paths),
+        "paths" -> SkemaJSONSerializer.pathsAsUJson(rm.paths),
         "tokenInterval" -> Map("start" -> rm.tokenInterval.start, "end" -> rm.tokenInterval.end),
         "characterStartOffset" -> rm.startOffset,
         "characterEndOffset" -> rm.endOffset,
@@ -383,7 +383,7 @@ object AutomatesJSONSerializer {
         "document" -> rm.document.equivalenceHash.toString,
         "keep" -> rm.keep,
         "foundBy" -> rm.foundBy,
-        "attachments" -> AutomatesJSONSerializer.toUJson(rm.attachments)
+        "attachments" -> SkemaJSONSerializer.toUJson(rm.attachments)
       )
     }
   }
@@ -398,7 +398,7 @@ object AutomatesJSONSerializer {
         "labels" -> em.labels,
         "trigger" -> AutomatesTextBoundMentionOps(em.trigger).toUJson,
         "arguments" -> argsToUJson(em.arguments),
-        "paths" -> AutomatesJSONSerializer.pathsAsUJson(em.paths),
+        "paths" -> SkemaJSONSerializer.pathsAsUJson(em.paths),
         "tokenInterval" -> Map("start" -> em.tokenInterval.start, "end" -> em.tokenInterval.end),
         "characterStartOffset" -> em.startOffset,
         "characterEndOffset" -> em.endOffset,
@@ -406,7 +406,7 @@ object AutomatesJSONSerializer {
         "document" -> em.document.equivalenceHash.toString,
         "keep" -> em.keep,
         "foundBy" -> em.foundBy,
-        "attachments" -> AutomatesJSONSerializer.toUJson(em.attachments)
+        "attachments" -> SkemaJSONSerializer.toUJson(em.attachments)
       )
     }
   }
@@ -461,7 +461,7 @@ object AutomatesJSONSerializer {
         "labels" -> cm.labels,
         "trigger" -> AutomatesTextBoundMentionOps(cm.trigger).toUJson,
         "arguments" -> argsToUJson(cm.arguments),
-        "paths" -> AutomatesJSONSerializer.pathsAsUJson(cm.paths),
+        "paths" -> SkemaJSONSerializer.pathsAsUJson(cm.paths),
         "tokenInterval" -> Map("start" -> cm.tokenInterval.start, "end" -> cm.tokenInterval.end),
         "characterStartOffset" -> cm.startOffset,
         "characterEndOffset" -> cm.endOffset,
@@ -470,7 +470,7 @@ object AutomatesJSONSerializer {
         "document" -> cm.document.equivalenceHash.toString,
         "keep" -> cm.keep,
         "foundBy" -> cm.foundBy,
-        "attachments" -> AutomatesJSONSerializer.toUJson(cm.attachments)
+        "attachments" -> SkemaJSONSerializer.toUJson(cm.attachments)
       )
     }
   }

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/utils/AlignmentJsonUtils.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/utils/AlignmentJsonUtils.scala
@@ -10,7 +10,7 @@ import org.ml4ai.skema.text_reading.OdinEngine
 import org.ml4ai.skema.text_reading.apps.{AlignmentArguments, AlignmentBaseline, AutomatesExporter, ExtractAndAlign}
 import org.ml4ai.skema.text_reading.grfn.GrFNParser
 import org.ml4ai.skema.text_reading.grounding.{sparqlResult, sparqlWikiResult}
-import org.ml4ai.skema.text_reading.serializer.AutomatesJSONSerializer
+import org.ml4ai.skema.text_reading.serializer.SkemaJSONSerializer
 import ujson.{Obj, Value}
 import ujson.json4s._
 import upickle.default.macroRW
@@ -68,7 +68,7 @@ object AlignmentJsonUtils {
       val mentionsFile = new File(mentionsPath)
       val textMentions =  if (serializerName == "AutomatesJSONSerializer") {
         val ujsonOfMenFile = ujson.read(mentionsFile)
-        AutomatesJSONSerializer.toMentions(ujsonOfMenFile)
+        SkemaJSONSerializer.toMentions(ujsonOfMenFile)
       } else {
         val ujsonMentions = ujson.read(mentionsFile.readString())
         //transform the mentions into json4s format, used by mention serializer
@@ -138,7 +138,7 @@ object AlignmentJsonUtils {
         val mentionsFile = new File(mentionsPath)
         val textMentions =  if (serializerName == "AutomatesJSONSerializer") {
           val ujsonOfMenFile = ujson.read(mentionsFile)
-          AutomatesJSONSerializer.toMentions(ujsonOfMenFile)
+          SkemaJSONSerializer.toMentions(ujsonOfMenFile)
         } else {
           val ujsonMentions = ujson.read(mentionsFile.readString())
           //transform the mentions into json4s format, used by mention serializer

--- a/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/utils/CommandLineArgumentParser.scala
+++ b/skema/text_reading/text_reading/src/main/scala/org/ml4ai/skema/text_reading/utils/CommandLineArgumentParser.scala
@@ -1,0 +1,47 @@
+package org.ml4ai.skema.text_reading.utils
+
+import scopt.OParser
+
+import java.io.File
+
+/**
+  * Command line arguments parsed by the text
+  */
+case class ArgsConfig(
+                       outDir: File = new File("."),
+                       inputFiles: Seq[File] = Seq(),
+                     )
+
+/**
+  * Fabric of command line arguments parsers for our app classes
+  */
+object CommandLineArgumentParser {
+  /**
+    * Builds a parser for entry-point apps with customizable program name
+    * @param appName Name of the app
+    * @return configured parser
+    */
+  def buildParser(appName:String): OParser[Unit, ArgsConfig] = {
+    val builder = OParser.builder[ArgsConfig]
+
+    val parser = {
+      import builder._
+      OParser.sequence(
+        programName(appName),
+        head(appName, "1.0"),
+        // option -f, --foo
+        opt[File]('o', "output_dir")
+          .required()
+          .action((x, c) => c.copy(outDir = x)).withFallback(() => new File("."))
+          .text("directory to write the output files to"),
+        // more options here...
+        arg[Seq[File]]("<input file 1>...")
+          .unbounded()
+          .action((x, c) => c.copy(inputFiles = x))
+          .text("files to annotate"),
+      )
+    }
+
+    parser
+  }
+}

--- a/skema/text_reading/text_reading/src/test/scala/org/ml4ai/skema/text_reading/serialization/TestConjDescrSerialization.scala
+++ b/skema/text_reading/text_reading/src/test/scala/org/ml4ai/skema/text_reading/serialization/TestConjDescrSerialization.scala
@@ -5,7 +5,7 @@ import org.clulab.odin.{Attachment, EventMention, Mention, RelationMention, Text
 import org.ml4ai.skema.test.ExtractionTest
 import org.ml4ai.skema.text_reading.attachments.AutomatesAttachment
 import org.ml4ai.skema.text_reading.mentions.CrossSentenceEventMention
-import org.ml4ai.skema.text_reading.serializer.AutomatesJSONSerializer
+import org.ml4ai.skema.text_reading.serializer.SkemaJSONSerializer
 
 
 // first, let's make crossSentenceMentions to export to JSON file
@@ -17,8 +17,8 @@ class TestConjDescrSerialization extends ExtractionTest {
   passingTest should s"successfully serialize and deserialize Description RelationMentions that went through conjunction-related post-processing (t1): ${t1}" taggedAs (Somebody) in {
     val mentions = extractMentions(t1)
     val DescrMentions = mentions.filter(m => m.label =="Description")
-    val uJson = AutomatesJSONSerializer.serializeMentions(DescrMentions)
-    val deserializedMentions = AutomatesJSONSerializer.toMentions(uJson)
+    val uJson = SkemaJSONSerializer.serializeMentions(DescrMentions)
+    val deserializedMentions = SkemaJSONSerializer.toMentions(uJson)
     getAttachmentJsonsFromArgs(deserializedMentions) should equal(getAttachmentJsonsFromArgs(DescrMentions))
     deserializedMentions should have size (DescrMentions.size)
     deserializedMentions.head.document.equivalenceHash should equal (DescrMentions.head.document.equivalenceHash)
@@ -33,14 +33,14 @@ class TestConjDescrSerialization extends ExtractionTest {
   passingTest should s"serialize and deserialize conjunction descriptions successfully from t2: ${t2}" taggedAs (Somebody) in {
     val mentions = extractMentions(t2)
     val conjDefMention = mentions.filter(m => m.labels.contains("ConjDescription"))
-    val uJson = AutomatesJSONSerializer.serializeMentions(conjDefMention)
-    val deserializedMentions = AutomatesJSONSerializer.toMentions(uJson)
+    val uJson = SkemaJSONSerializer.serializeMentions(conjDefMention)
+    val deserializedMentions = SkemaJSONSerializer.toMentions(uJson)
     deserializedMentions should have size (conjDefMention.size)
     deserializedMentions.head.document.equivalenceHash should equal (conjDefMention.head.document.equivalenceHash)
     deserializedMentions.head.text should equal(conjDefMention.head.text)
     deserializedMentions.head.asInstanceOf[EventMention].sentence should equal(conjDefMention.head.asInstanceOf[EventMention].sentence)
-    val hashesDeser = deserializedMentions.map(m => AutomatesJSONSerializer.AutomatesEventMentionOps(m.asInstanceOf[EventMention]).equivalenceHash).toSet
-    val hashesOrig = conjDefMention.map(m =>  AutomatesJSONSerializer.AutomatesEventMentionOps(m.asInstanceOf[EventMention]).equivalenceHash).toSet
+    val hashesDeser = deserializedMentions.map(m => SkemaJSONSerializer.AutomatesEventMentionOps(m.asInstanceOf[EventMention]).equivalenceHash).toSet
+    val hashesOrig = conjDefMention.map(m =>  SkemaJSONSerializer.AutomatesEventMentionOps(m.asInstanceOf[EventMention]).equivalenceHash).toSet
     hashesDeser should equal(hashesOrig)
   }
 
@@ -48,8 +48,8 @@ class TestConjDescrSerialization extends ExtractionTest {
   passingTest should s"serialize and deserialize the Description EventMentions successfully from t3: ${t3}" taggedAs (Somebody) in {
     val mentions = extractMentions(t3)
     val DescrMentions = mentions.filter(m => m.label == "Description")
-    val uJson = AutomatesJSONSerializer.serializeMentions(DescrMentions)
-    val deserializedMentions = AutomatesJSONSerializer.toMentions(uJson)
+    val uJson = SkemaJSONSerializer.serializeMentions(DescrMentions)
+    val deserializedMentions = SkemaJSONSerializer.toMentions(uJson)
     getAttachmentJsonsFromArgs(deserializedMentions) should equal(getAttachmentJsonsFromArgs(DescrMentions))
     deserializedMentions should have size (DescrMentions.size)
     deserializedMentions.head.document.equivalenceHash should equal(DescrMentions.head.document.equivalenceHash)
@@ -65,14 +65,14 @@ class TestConjDescrSerialization extends ExtractionTest {
     val mentions = extractMentions(t4)
     val conjDefMention = mentions.filter(m => m.labels.contains("ConjDescription"))
     // TODO: conjDefMention is empty which will cause an exception shortly.
-    val uJson = AutomatesJSONSerializer.serializeMentions(conjDefMention)
-    val deserializedMentions = AutomatesJSONSerializer.toMentions(uJson)
+    val uJson = SkemaJSONSerializer.serializeMentions(conjDefMention)
+    val deserializedMentions = SkemaJSONSerializer.toMentions(uJson)
     deserializedMentions should have size (conjDefMention.size)
     deserializedMentions.head.document.equivalenceHash should equal (conjDefMention.head.document.equivalenceHash)
     deserializedMentions.head.text should equal(conjDefMention.head.text)
     deserializedMentions.head.asInstanceOf[EventMention].sentence should equal(conjDefMention.head.asInstanceOf[EventMention].sentence)
-    val hashesDeser = deserializedMentions.map(m => AutomatesJSONSerializer.AutomatesEventMentionOps(m.asInstanceOf[EventMention]).equivalenceHash).toSet
-    val hashesOrig = conjDefMention.map(m =>  AutomatesJSONSerializer.AutomatesEventMentionOps(m.asInstanceOf[EventMention]).equivalenceHash).toSet
+    val hashesDeser = deserializedMentions.map(m => SkemaJSONSerializer.AutomatesEventMentionOps(m.asInstanceOf[EventMention]).equivalenceHash).toSet
+    val hashesOrig = conjDefMention.map(m =>  SkemaJSONSerializer.AutomatesEventMentionOps(m.asInstanceOf[EventMention]).equivalenceHash).toSet
     hashesDeser should equal(hashesOrig)
   }
 }

--- a/skema/text_reading/text_reading/src/test/scala/org/ml4ai/skema/text_reading/serialization/TestCrossSentenceSerialization.scala
+++ b/skema/text_reading/text_reading/src/test/scala/org/ml4ai/skema/text_reading/serialization/TestCrossSentenceSerialization.scala
@@ -2,7 +2,7 @@ package org.ml4ai.skema.text_reading.serialization
 
 import org.ml4ai.skema.test.ExtractionTest
 import org.ml4ai.skema.text_reading.mentions.CrossSentenceEventMention
-import org.ml4ai.skema.text_reading.serializer.AutomatesJSONSerializer
+import org.ml4ai.skema.text_reading.serializer.SkemaJSONSerializer
 
 class TestCrossSentenceSerialization extends ExtractionTest {
 
@@ -11,9 +11,9 @@ class TestCrossSentenceSerialization extends ExtractionTest {
       val mentions = extractMentions(textToTest)
       val crossSentenceMentions = mentions.filter(m => m.isInstanceOf[CrossSentenceEventMention]).distinct
       // serialize mentions (into a json object)
-      val uJson = AutomatesJSONSerializer.serializeMentions(crossSentenceMentions)
+      val uJson = SkemaJSONSerializer.serializeMentions(crossSentenceMentions)
       // and read them back in from the json
-      val deserializedMentions = AutomatesJSONSerializer.toMentions(uJson)
+      val deserializedMentions = SkemaJSONSerializer.toMentions(uJson)
       // check if all mentions have been deserialized
       deserializedMentions should have size (crossSentenceMentions.size)
       // check the documents idea has been preserved
@@ -25,8 +25,8 @@ class TestCrossSentenceSerialization extends ExtractionTest {
       // check if mention ids match---use hashes created with our CrossSentenceEventMentionOps---not generic CrossSentenceMentionOps found in clulab processors;
       // for other types of mentions, it should be fine to use Ops from processors
       // this might be a little overcomplicated, but it seems to work
-      val hashesDeser = deserializedMentions.map(m => AutomatesJSONSerializer.CrossSentenceEventMentionOps(m.asInstanceOf[CrossSentenceEventMention]).equivalenceHash).toSet
-      val hashesOrig = crossSentenceMentions.map(m =>  AutomatesJSONSerializer.CrossSentenceEventMentionOps(m.asInstanceOf[CrossSentenceEventMention]).equivalenceHash).toSet
+      val hashesDeser = deserializedMentions.map(m => SkemaJSONSerializer.CrossSentenceEventMentionOps(m.asInstanceOf[CrossSentenceEventMention]).equivalenceHash).toSet
+      val hashesOrig = crossSentenceMentions.map(m =>  SkemaJSONSerializer.CrossSentenceEventMentionOps(m.asInstanceOf[CrossSentenceEventMention]).equivalenceHash).toSet
       hashesDeser should equal(hashesOrig)
     }
   }

--- a/skema/text_reading/text_reading/webapp/app/controllers/HomeController.scala
+++ b/skema/text_reading/text_reading/webapp/app/controllers/HomeController.scala
@@ -27,7 +27,7 @@ import org.ml4ai.skema.text_reading.cosmosjson.CosmosJsonProcessor
 import org.ml4ai.skema.text_reading.data.{CosmosJsonDataLoader, ScienceParsedDataLoader}
 import org.ml4ai.skema.text_reading.grounding.{GrounderFactory, SVOGrounder, WikidataGrounder}
 import org.ml4ai.skema.text_reading.scienceparse.ScienceParseClient
-import org.ml4ai.skema.text_reading.serializer.AutomatesJSONSerializer
+import org.ml4ai.skema.text_reading.serializer.SkemaJSONSerializer
 import org.ml4ai.skema.text_reading.utils.{AlignmentJsonUtils, DisplayUtils}
 import org.slf4j.{Logger, LoggerFactory}
 import ujson.json4s.Json4sJson
@@ -84,7 +84,7 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
 
 
 
-  private val cosmosPipeline = new CosmosTextReadingPipeline
+  private val cosmosPipeline = new CosmosTextReadingPipeline(contextWindowSize = 3) // TODO Add the window parameter to the configuration file
 
 
   logger.info("Completed Initialization ...")
@@ -146,7 +146,7 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
     val mentionsFile = new File(mentionsPath)
 
     val ujsonOfMenFile = ujson.read(mentionsFile)
-    val defMentions = AutomatesJSONSerializer.toMentions(ujsonOfMenFile).filter(m => m.label contains "Description")
+    val defMentions = SkemaJSONSerializer.toMentions(ujsonOfMenFile).filter(m => m.label contains "Description")
     val glVars = WikidataGrounder.mentionsToGlobalVarsWithWikidataGroundings(defMentions)
 
     Ok(glVars).as(JSON)

--- a/skema/text_reading/text_reading/webapp/app/controllers/HomeController.scala
+++ b/skema/text_reading/text_reading/webapp/app/controllers/HomeController.scala
@@ -19,7 +19,7 @@ import org.clulab.serialization.json.stringify
 import org.slf4j.{Logger, LoggerFactory}
 import org.json4s
 import org.json4s.{JArray, JValue}
-import org.ml4ai.skema.text_reading.{CosmosTextReadingPipeline, OdinEngine}
+import org.ml4ai.skema.text_reading.{CosmosTextReadingPipeline, OdinEngine, TextReadingPipelineWithContext}
 import org.ml4ai.skema.text_reading.alignment.{Aligner, AlignmentHandler}
 import org.ml4ai.skema.text_reading.apps.{AutomatesExporter, ExtractAndAlign}
 import org.ml4ai.skema.text_reading.attachments.{GroundingAttachment, MentionLocationAttachment}
@@ -63,6 +63,7 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
   val config: Config = defaultConfig.withValue("preprocessorType", ConfigValueFactory.fromAnyRef("PassThrough"))
   val groundingConfig = generalConfig.getConfig("Grounding")
   val miraEmbeddingsGrounder = GrounderFactory.getInstance(groundingConfig, chosenEngine = Some("miraembeddings"))
+  val textReadingPipelineWithContext = new TextReadingPipelineWithContext()
   val ieSystem = OdinEngine.fromConfig(config)
   var proc = ieSystem.proc
   val serializer = JSONSerializer
@@ -167,6 +168,13 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
     playJson
   }
 
+  def ujsonToPlayJson(value: ujson.Value): JsValue = {
+    val json = ujson.write(value)
+    val playJson = Json.parse(json)
+
+    playJson
+  }
+
   def groundStringsToMira(k: Int): Action[AnyContent] = Action { request =>
     val text = request.body.asText.get
     val texts = Source.fromString(text).getLines.map(_.trim).filter(_.nonEmpty).toVector
@@ -174,6 +182,20 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
     val jGroundingCandidates = groundingCandidates.map(_.map(_.toJValue).toList).toList
     val json4sResult = JArray(jGroundingCandidates.map(JArray(_)))
     val playJsonResult = json4sToPlayJson(json4sResult)
+
+    Ok(playJsonResult)
+  }
+
+  def runTextReadingPipelineWithContext(contextWindowSize: Int = 3) = Action { request =>
+    val texts = request.body.asJson.get.as[Array[String]]
+    val ujsonResults = texts.map { text =>
+      val mentions = textReadingPipelineWithContext.extractMentionsWithContext(text, contextWindowSize)
+      val ujsonResult = SkemaJSONSerializer.serializeMentions(mentions)
+
+      ujsonResult
+    }
+    val ujsonResult = ujson.Arr.from(ujsonResults)
+    val playJsonResult = ujsonToPlayJson(ujsonResult)
 
     Ok(playJsonResult)
   }

--- a/skema/text_reading/text_reading/webapp/conf/routes
+++ b/skema/text_reading/text_reading/webapp/conf/routes
@@ -4,23 +4,25 @@
 # ~~~~
 
 # An example controller showing a sample home page
-GET     /                           controllers.HomeController.index
-GET     /parseSentence              controllers.HomeController.parseSentence(sent: String, showEverything: Boolean)
-GET     /getMentions                controllers.HomeController.getMentions(text: String)
-POST    /groundStringToSVO          controllers.HomeController.groundStringToSVO
-POST    /groundStringsToMira        controllers.HomeController.groundStringsToMira(k: Int)
-POST    /groundMentionsToSVO        controllers.HomeController.groundMentionsToSVO
-POST    /groundMentionsToWikidata   controllers.HomeController.groundMentionsToWikidata
-POST    /process_text               controllers.HomeController.process_text
-POST    /pdf_to_mentions            controllers.HomeController.pdf_to_mentions
-POST    /align                      controllers.HomeController.align
-POST    /json_doc_to_mentions       controllers.HomeController.json_doc_to_mentions
-POST    /cosmos_json_to_mentions    controllers.HomeController.cosmos_json_to_mentions
-POST    /alignMentionsFromTwoModels controllers.HomeController.alignMentionsFromTwoModels
+GET     /                                  controllers.HomeController.index
+GET     /parseSentence                     controllers.HomeController.parseSentence(sent: String, showEverything: Boolean)
+GET     /getMentions                       controllers.HomeController.getMentions(text: String)
+POST    /groundStringToSVO                 controllers.HomeController.groundStringToSVO
+POST    /groundMentionsToSVO               controllers.HomeController.groundMentionsToSVO
+POST    /groundMentionsToWikidata          controllers.HomeController.groundMentionsToWikidata
+POST    /process_text                      controllers.HomeController.process_text
+POST    /pdf_to_mentions                   controllers.HomeController.pdf_to_mentions
+POST    /align                             controllers.HomeController.align
+POST    /json_doc_to_mentions              controllers.HomeController.json_doc_to_mentions
+POST    /cosmos_json_to_mentions           controllers.HomeController.cosmos_json_to_mentions
+POST    /alignMentionsFromTwoModels        controllers.HomeController.alignMentionsFromTwoModels
 
-GET     /api/skema                  controllers.HomeController.openAPI(version = "v1")
-GET     /api/skema/:version         controllers.HomeController.openAPI(version: String)
+POST    /groundStringsToMira               controllers.HomeController.groundStringsToMira(k: Int)
+POST    /runTextReadingPipelineWithContext controllers.HomeController.runTextReadingPipelineWithContext(contextWindowSize: Int = 3)
+
+GET     /api/skema                         controllers.HomeController.openAPI(version = "v1")
+GET     /api/skema/:version                controllers.HomeController.openAPI(version: String)
 
 # Map static resources from the /public folder to the /assets URL path
-GET     /favicon.ico                controllers.Assets.at(file="/images/favicon.ico")
-GET     /assets/*file               controllers.Assets.at(file)
+GET     /favicon.ico                       controllers.Assets.at(file="/images/favicon.ico")
+GET     /assets/*file                      controllers.Assets.at(file)

--- a/skema/text_reading/text_reading/webapp/public/schema/api-v1.yaml
+++ b/skema/text_reading/text_reading/webapp/public/schema/api-v1.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: SKEMA API
-  version: "1.0.0"
+  version: "1.0.1"
   description: RESTful API exposing functionality of the SKEMA project
   contact:
     name: Clayton T. Morrison
@@ -56,8 +56,57 @@ paths:
                   items:
                     $ref: "#/components/schemas/GroundingCandidate"
 
+  /runTextReadingPipelineWithContext:
+    post:
+      tags:
+        - "grounding"
+      summary: |
+        run the text reading pipeline with context
+      description: |
+        run the text reading pipeline with context
+      parameters:
+        - name: contextWindowSize
+          in: query
+          description: the window size for the context
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 3
+      requestBody:
+        description: an array of texts, each probably one or more sentences, perhaps entire documents
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              description: one text, probably at least a sentence if not an entire document
+              items:
+                type: string
+              example: |
+                [
+                  "Far out in the uncharted backwaters of the unfashionable end of the western spiral arm of the Galaxy lies a small, unregarded yellow sun.",
+                  "It was a bright cold day in April, and the clocks were striking thirteen.",
+                  "The year 1866 was signalized by a remarkable incident, a mysterious and inexplicable phenomenon, which doubtless no one has yet forgotten."
+                ]
+      responses:
+        '200':
+          description: output for successful run of the text reading pipeline for the input texts
+          content:
+            application/json:
+              schema:
+                type: array
+                description: for each of the input texts, output from the text reading pipeline
+                items:
+                  type: array
+                  description: output from the text reading pipeline for a single text
+                  items:
+                    $ref: "#/components/schemas/Annotation"
+
 components:
   schemas:
+    Annotation:
+      type: string
     GroundingCandidate:
         type: object
         description: a ranked list of k grounding concepts


### PR DESCRIPTION
This PR addressed #153

- Adds an app to process plain text files, in addition to the existing one that reads Cosmos Json files
- Adds an in-memory text reading pipeline with scenario context (for use in the web api)
- Renames the JSON serializer from `AutomatesJSONSerializer` to `SkemaJSONSerializer`