### PR TITLE
Adding currently supportd space weather files from TIE_GCM model

### DIFF
--- a/data/TIE_GCM/cons.F
+++ b/data/TIE_GCM/cons.F
@@ -1,0 +1,115 @@
+
+program cons_module
+!
+! This software is part of the NCAR TIE-GCM.  Use is governed by the 
+! Open Source Academic Research License Agreement contained in the file 
+! tiegcmlicense.txt.
+!
+use params_module,only: dlat,dz,nlon,nlonp1,nlonp4,nlat,nlatp1,
+|  dlev,nlev,nmlat,nmlon,nmlonp1,zmbot,zmtop,zibot,zitop,dlon,
+|  glon,glat,glon1,glat1,zpmid,zpint,gmlon,gmlat,zpmag,zpimag,
+|  dmlev,nlevp1,nmlevp1,nimlevp1,zpbot_dyn,zpibot_dyn
+implicit none
+!
+! Define model constants. 
+! Parameter constants are cons_module module data and are accessed 
+!   in subroutines via use-association. 
+! Derived constants are cons_module module data, and are calculated
+!   in sub init_cons (contained in cons_module). 
+!   Sub init_cons is called by sub init (init_mod.F).
+! Parameter constants:
+!
+integer,parameter :: ndays =366  ! maximum number of days in a year
+real,parameter ::
+|  dzp  = dz,           ! alias for dz (also dlev)
+|  re   = 6.37122e8,    ! earth radius (cm)                  C(51)
+|  re_dyn = 6.378165e8, ! earth radius for apex
+|  re_inv = 1./re,      ! inverse of earth radius            C(52)
+|  avo  = 6.023e23,     ! avogadro number                    C(85)
+|  boltz = 1.38E-16,    ! boltzman's constant                C(84)
+|  p0   = 5.0e-4,       ! standard pressure                  C(81)
+|  gask = 8.314e7,      ! gas constant                       C(57)
+|  grav_par = 3.986004415e20 ! standard gravitational parameter (cm^3/sec^2)
+
+!
+! Smoothing constant is dependent on timestep (see below), so cannot be a parameter.
+! (in previous revisions, shapiro=3.e-2, with no timestep or resolution dependence)
+!
+  real :: shapiro      ! shapiro smoother constant
+  real :: default_step ! default timestep at current resolution.
+  real :: smooth_fac   ! smoothing factor (typically 3.e-3)
+!
+integer :: nlonper=nlonp4 ! nlon + periodic points (alias for nlonp4)
+!
+! Many expressions require x/rmass, but its more efficient on some
+! platforms to multiply rather than divide, so set rmassinv = 1./rmass 
+! here, and use x*rmassinv in the code.
+!
+real,parameter :: 
+|  rmass_o2 = 32., rmass_o1  = 16., rmass_n2  = 28., 
+|  rmass_o3 = 48., rmass_n4s = 14., rmass_n2d = 14., 
+|  rmass_no = 30., rmass_op  = 16., rmass_co2 = 44.,
+|  rmass_he =  4., rmass_ar  = 40.
+real,parameter ::
+|  rmassinv_o2  = 1./rmass_o2,
+|  rmassinv_o1  = 1./rmass_o1,
+|  rmassinv_n2  = 1./rmass_n2,
+|  rmassinv_o3  = 1./rmass_o3,
+|  rmassinv_n4s = 1./rmass_n4s,
+|  rmassinv_n2d = 1./rmass_n2d,
+|  rmassinv_no  = 1./rmass_no,
+|  rmassinv_op  = 1./rmass_op,
+|  rmassinv_he  = 1./rmass_he,
+|  rmassinv_ar  = 1./rmass_ar
+!
+! Model derived constants (see sub init_cons in this module):
+!
+real ::
+|  pi,             ! set with 4*atan(1)    C(110)
+|  sqrtpi,         ! sqrt(pi)
+|  rtd,            ! radians-to-degrees (180./pi)
+|  dtr,            ! degrees-to-radians (pi/180.)
+|  dphi,           ! delta lat (pi/nlat)   C(2)
+|  dphi_2div3,     ! 2./(3.*dphi)          C(12)
+|  dphi_1div12,    ! 1./(12.*dphi)         C(13)
+|  dphi2_5div2,    ! 5./(2.*dphi**2)
+|  dphi2_4div3,    ! 4./(3.*dphi**2)
+|  dphi2_1div12,   ! 1./(12.*dphi**2)
+|  dlamda,         ! delta lon (2pi/nlon)  C(1)
+|  dlamda_2div3,   ! 2./(3.*dlamda)        C(10)
+|  dlamda_1div12,  ! 1./(12.*dlamda)       C(11)
+|  dlamda2_5div2,  ! 5./(2.*dlamda**2)
+|  dlamda2_4div3,  ! 4./(3.*dlamda**2)
+|  dlamda2_1div12, ! 1./(12.*dlamda**2)
+|  dt,             ! time step (secs)      C(4)
+|  dtx2,           ! 2*dt                  C(6)
+|  dtx2inv,        ! 1./(2*dt)             C(7)
+|  freq_3m3,       ! frequency of 2-day wave (rad/sec)       C(21)
+|  freq_semidi,    ! frequency of semidiurnal tide (rad/sec) C(23)
+|  expzmid,        ! exp(-.5*dz)                             C(86)
+|  expzmid_inv,    ! 1./expzmid                              C(87)
+|  grav,           ! accel due to gravity (dependent on lower boundary)
+|  dzgrav,         ! grav/gask C(65)
+|  zbound          ! background low bound of Z (formerly ZBA in annual tide)
+!
+! Constants for dynamo and electric field calculations:
+real,parameter :: h0 =9.0e6, r0 =re+h0    ! use mean earth radius
+!
+! Save gdlat,gdlon(nmlonp1,nmlat) in degrees from apex for sub define_mag (mpi.F)
+!     real,dimension(nmlonp1,nmlat) :: gdlatdeg,gdlondeg
+
+real,parameter :: hs=1.3e7
+real ::
+|  dlatg, dlong, dlatm, dlonm,dmagphrlon
+
+!
+! Special pi for mag field calculations. If pi=4.*atan(1.) and code is
+! linked with -lmass lib, then the last 2 digits (16th and 17th) of pi
+! are different (56 instead of 12), resulting in theta0(j=49)==0., which 
+! is wrong (should be .1110e-15).
+!
+real,parameter :: pi_dyn=3.14159265358979312
+
+integer,parameter :: difhor=1
+
+end program cons_module

--- a/data/TIE_GCM/cpktkm.F
+++ b/data/TIE_GCM/cpktkm.F
@@ -1,0 +1,119 @@
+!
+      subroutine cpktkm(tn,o2,o1,n2,he,fcp,fkt,fkm,lev0,lev1,lon0,lon1,
+          |  lat)
+       !
+       ! This software is part of the NCAR TIE-GCM.  Use is governed by the 
+       ! Open Source Academic Research License Agreement contained in the file 
+       ! tiegcmlicense.txt.
+       !
+       ! Define diagnostics CP, KT, and KM.
+       !
+             use cons_module,only: rmassinv_o2,rmassinv_o1,rmassinv_n2,
+            |                      rmassinv_he,gask,t0
+             use addfld_module,only: addfld
+             use diags_module,only: mkdiag_MU_M
+             implicit none
+       !
+       ! Args:
+             integer,intent(in) :: lev0,lev1,lon0,lon1,lat
+             real,dimension(lev0:lev1,lon0-2:lon1+2),intent(in) :: 
+            |  tn,  ! neutral temperature (deg K)
+            |  o2,  ! molecular oxygen (mmr)
+            |  o1,  ! atomic oxygen (mmr)
+            |  n2,  ! molecular nitrogen (mmr)
+            |  he   ! helium (mmr)
+             real,dimension(lev0:lev1,lon0-2:lon1+2),intent(out) :: 
+            |  fcp, ! specific heat at constant pressure (ergs/deg/gm)
+            |  fkt, ! molecular diffusion (ergs/cm/deg/sec)
+            |  fkm  ! molecular viscosity (gm/cm/sec)
+       !
+       ! Local:
+             integer :: k,i
+             real,dimension(lev0:lev1,lon0:lon1) ::
+            |  fmbar,        ! mean mass
+            |  po2,po1,pn2,phe 
+             integer :: nlons,nlevs
+       !
+             nlons = lon1-lon0+1
+             nlevs = lev1-lev0+1
+       
+       !     call addfld('tn_cp',' ',' ',tn(:,lon0:lon1),'lev',lev0,lev1,
+       !    |  'lon',lon0,lon1,lat)
+       !     call addfld('o2_cp',' ',' ',o2(:,lon0:lon1),'lev',lev0,lev1,
+       !    |  'lon',lon0,lon1,lat)
+       !     call addfld('o1_cp',' ',' ',o1(:,lon0:lon1),'lev',lev0,lev1,
+       !    |  'lon',lon0,lon1,lat)
+       
+       ! Modified by EKS (Eric Sutton):
+       !  Compute po2, po1, phe, and pn2 as the number density mixing ratios.
+       !  Add the effect of Helium to the cp,km,kt calculations consistent with
+       !  Banks and Kockarts, 1973.
+             do i=lon0,lon1
+               do k=lev0,lev1
+                 fmbar(k,i) = 1./(o2(k,i)*rmassinv_o2 + o1(k,i)*rmassinv_o1 +
+            |                 he(k,i)*rmassinv_he + n2(k,i)*rmassinv_n2)
+                 po2(k,i) = fmbar(k,i)*o2(k,i)*rmassinv_o2
+                 po1(k,i) = fmbar(k,i)*o1(k,i)*rmassinv_o1
+                 phe(k,i) = fmbar(k,i)*he(k,i)*rmassinv_he
+                 pn2(k,i) = fmbar(k,i)*n2(k,i)*rmassinv_n2
+                 fcp(k,i) = gask*.5*(po2(k,i)*7./32.+pn2(k,i)*7./28.+
+            |                        po1(k,i)*5./16.+phe(k,i)*5./4.)
+                 fkm(k,i) = po2(k,i)*4.03 + pn2(k,i)*3.42 + po1(k,i)*3.9 +
+            |               phe(k,i)*3.84
+                 fkt(k,i) = (po2(k,i)+pn2(k,i))*56. + po1(k,i)*75.9 + 
+            |                phe(k,i)*299.
+               enddo
+             enddo
+       
+       !     call addfld('fcp1',' ',' ',fcp(:,lon0:lon1),'lev',lev0,lev1,
+       !    |  'lon',lon0,lon1,lat)
+       !     call addfld('fkm1',' ',' ',fkm(:,lon0:lon1),'lev',lev0,lev1,
+       !    |  'lon',lon0,lon1,lat)
+       !     call addfld('fkt1',' ',' ',fkt(:,lon0:lon1),'lev',lev0,lev1,
+       !    |  'lon',lon0,lon1,lat)
+       
+             do i=lon0,lon1
+               do k=lev0,lev1-1
+                 fkm(k,i) = fkm(k,i)*(tn(k,i)+.5*(t0(k)+t0(k+1)))**0.69*1.e-6
+                 fkt(k,i) = fkt(k,i)*(tn(k,i)+.5*(t0(k)+t0(k+1)))**0.69
+               enddo
+             enddo
+             do i=lon0,lon1
+               fkm(lev1,i) = 1.e-6*fkm(lev1,i)*(tn(lev1-1,i)+
+            |                1.5*t0(lev1)-.5*t0(lev1-1))**0.69
+               fkt(lev1,i) =       fkt(lev1,i)*(tn(lev1-1,i)+
+            |                1.5*t0(lev1)-.5*t0(lev1-1))**0.69
+             enddo
+       
+       !     call addfld('fcp2',' ',' ',fcp(:,lon0:lon1),'lev',lev0,lev1,
+       !    |  'lon',lon0,lon1,lat)
+       !     call addfld('fkm2',' ',' ',fkm(:,lon0:lon1),'lev',lev0,lev1,
+       !    |  'lon',lon0,lon1,lat)
+       !     call addfld('fkt2',' ',' ',fkt(:,lon0:lon1),'lev',lev0,lev1,
+       !    |  'lon',lon0,lon1,lat)
+       
+             do i=lon0,lon1
+               do k=lev1,lev0+1,-1
+                 fcp(k,i) = .5*(fcp(k,i)+fcp(k-1,i))
+                 fkm(k,i) = .5*(fkm(k,i)+fkm(k-1,i))
+                 fkt(k,i) = .5*(fkt(k,i)+fkt(k-1,i))
+               enddo 
+             enddo
+             do i=lon0,lon1
+               fcp(1,i) = 2.*fcp(1,i)-fcp(2,i)
+               fkm(1,i) = 2.*fkm(1,i)-fkm(2,i)
+               fkt(1,i) = 2.*fkt(1,i)-fkt(2,i)
+             enddo
+       
+       !     call addfld('CP',' ',' ',fcp(:,lon0:lon1),'lev',lev0,lev1,
+       !    |  'lon',lon0,lon1,lat)
+       !     call addfld('KT',' ',' ',fkt(:,lon0:lon1),'lev',lev0,lev1,
+       !    |  'lon',lon0,lon1,lat)
+       !     call addfld('KM',' ',' ',fkm(:,lon0:lon1),'lev',lev0,lev1,
+       !    |  'lon',lon0,lon1,lat)
+       !
+       ! Save molecular viscosity diagnostic:
+             call mkdiag_MU_M('MU_M',fkm(:,lon0:lon1),lev0,lev1,lon0,lon1,lat)
+       
+             end subroutine cpktkm
+       


### PR DESCRIPTION
Adding `cons.F` and `cpktkm.F` Fortran source files from the TIE_GCM space weather model to the data directory.

Note: For some reason, Github's syntax highlighter is having issues with these files, but they are valid and parsable Fortran files.  

Resolves issue #177 