### PR TITLE
[CODE2FN] single_file_ingester fixes and snippet_ingester creation 

### DIFF
--- a/skema/program_analysis/single_file_ingester.py
+++ b/skema/program_analysis/single_file_ingester.py
@@ -1,16 +1,23 @@
 import argparse
 import tempfile
 import os
+from pathlib import Path
 
 from skema.program_analysis.multi_file_ingester import process_file_system
+from skema.gromet.fn import GrometFNModuleCollection
+def process_file(path: str, write_to_file=False) -> GrometFNModuleCollection:
+    ''' Run a single Python or Fortran file through the CODE2FN pipeline and return the GrometFNModuleCollection.
+        Optionally, output the Gromet JSON to a file.
+    '''
 
-def process_file(path: str, write_to_file=False):
-    system_name = os.path.basename(path).strip(".py")
-    root_path = os.path.dirname(path)
-
+    path_obj = Path(path)
+    system_name = path_obj.stem
+    file_name = path_obj.name
+    root_path = str(path_obj.parent)
+    
     # Create temporary system_filepaths file
     tmp = tempfile.NamedTemporaryFile(mode="w", delete=False)
-    tmp.write(os.path.basename(path))
+    tmp.write(file_name)
     tmp.close()
 
     gromet_collection = process_file_system(system_name, root_path, tmp.name, write_to_file)
@@ -23,7 +30,7 @@ def process_file(path: str, write_to_file=False):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--path", type=str, help="The path of source directory"
+        "path", type=str, help="The relative or absolute path of the file to process"
     )
     args = parser.parse_args()
     process_file(args.path, True)

--- a/skema/program_analysis/single_file_ingester.py
+++ b/skema/program_analysis/single_file_ingester.py
@@ -5,27 +5,32 @@ from pathlib import Path
 
 from skema.program_analysis.multi_file_ingester import process_file_system
 from skema.gromet.fn import GrometFNModuleCollection
+
+
 def process_file(path: str, write_to_file=False) -> GrometFNModuleCollection:
-    ''' Run a single Python or Fortran file through the CODE2FN pipeline and return the GrometFNModuleCollection.
-        Optionally, output the Gromet JSON to a file.
-    '''
+    """Run a single Python or Fortran file through the CODE2FN pipeline and return the GrometFNModuleCollection.
+    Optionally, output the Gromet JSON to a file.
+    """
 
     path_obj = Path(path)
     system_name = path_obj.stem
     file_name = path_obj.name
     root_path = str(path_obj.parent)
-    
+
     # Create temporary system_filepaths file
     tmp = tempfile.NamedTemporaryFile(mode="w", delete=False)
     tmp.write(file_name)
     tmp.close()
 
-    gromet_collection = process_file_system(system_name, root_path, tmp.name, write_to_file)
+    gromet_collection = process_file_system(
+        system_name, root_path, tmp.name, write_to_file
+    )
 
     # Delete temporary system_filepaths file
     os.unlink(tmp.name)
 
     return gromet_collection
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/skema/program_analysis/snippet_ingester.py
+++ b/skema/program_analysis/snippet_ingester.py
@@ -5,11 +5,14 @@ import os
 from skema.program_analysis.single_file_ingester import process_file
 from skema.gromet.fn import GrometFNModuleCollection
 
-def process_snippet(source: str, extension:str, write_to_file=False) -> GrometFNModuleCollection:
-    ''' Run a Python or Fortran code snippet through the CODE2FN pipeline and return the GrometFNModuleCollection.
-        Optionally, output the Gromet JSON to a file.
-    '''
-    
+
+def process_snippet(
+    source: str, extension: str, write_to_file=False
+) -> GrometFNModuleCollection:
+    """Run a Python or Fortran code snippet through the CODE2FN pipeline and return the GrometFNModuleCollection.
+    Optionally, output the Gromet JSON to a file.
+    """
+
     # Create temporary snippet file
     tmp = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=extension)
     tmp.write(source)
@@ -22,13 +25,14 @@ def process_snippet(source: str, extension:str, write_to_file=False) -> GrometFN
 
     return gromet_collection
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
+    parser.add_argument("source", type=str, help="Python or Fortran source code")
     parser.add_argument(
-        "source", type=str, help="Python or Fortran source code"
-    )
-    parser.add_argument(
-        "extension", type=str, help="The language file extension of the code snippet (i.e. .py, .f95)"
+        "extension",
+        type=str,
+        help="The language file extension of the code snippet (i.e. .py, .f95)",
     )
     args = parser.parse_args()
     process_snippet(args.source, args.extension, True)

--- a/skema/program_analysis/snippet_ingester.py
+++ b/skema/program_analysis/snippet_ingester.py
@@ -1,0 +1,34 @@
+import argparse
+import tempfile
+import os
+
+from skema.program_analysis.single_file_ingester import process_file
+from skema.gromet.fn import GrometFNModuleCollection
+
+def process_snippet(source: str, extension:str, write_to_file=False) -> GrometFNModuleCollection:
+    ''' Run a Python or Fortran code snippet through the CODE2FN pipeline and return the GrometFNModuleCollection.
+        Optionally, output the Gromet JSON to a file.
+    '''
+    
+    # Create temporary snippet file
+    tmp = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=extension)
+    tmp.write(source)
+    tmp.close()
+
+    gromet_collection = process_file(tmp.name, write_to_file)
+
+    # Delete temporary snippet file
+    os.unlink(tmp.name)
+
+    return gromet_collection
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "source", type=str, help="Python or Fortran source code"
+    )
+    parser.add_argument(
+        "extension", type=str, help="The language file extension of the code snippet (i.e. .py, .f95)"
+    )
+    args = parser.parse_args()
+    process_snippet(args.source, args.extension, True)


### PR DESCRIPTION
Fixes filename truncation bug when running the pipeline with single_file_ingester.py. 

Fixes additional bug in single_file_ingester where the `path` argument was previously optional. 

Creates a new ingestion script snippet_ingester.py to ingest code snippets instead of files. Its two arguments are the source string itself and a file extension associated with the snippet language (We need this to pass down the pipeline so we know which language we are working with). 

For example:
```bash
python snippet_ingester.py "x=2" ".py"
```

Resolves #202 