### PR TITLE
Taking input and output paths as arguments.

### DIFF
--- a/skema/text_reading/text_reading/annotate_cosmos_json
+++ b/skema/text_reading/text_reading/annotate_cosmos_json
@@ -30,5 +30,8 @@ cp ${input}/*.json ${json_input}
 # Convert parquet to jsons
 python3 cosmos_integration.py -o ${json_input} ${input}
 
+# Only keep the "--COSMOS-data.json" files, other files are not meant to be read by the pipeline
+find ${json_input} -type f -not -name "*COSMOS-data.json" -exec rm {} \;
+
 # Run the TR pipeline
 java -jar target/scala-2.12/skema_text_reading-assembly-0.1.0-SNAPSHOT.jar org.ml4ai.skema.text_reading.apps.AnnotateCosmosJsonFiles -o ${output} ${json_input}

--- a/skema/text_reading/text_reading/annotate_cosmos_json
+++ b/skema/text_reading/text_reading/annotate_cosmos_json
@@ -1,11 +1,34 @@
 #!/bin/sh
 # Shell utility to run the cosmos annotation app with default values
+usage() { echo "Usage: $0 [-i <input path>] [-o <output path>] [-j <json_input path>]" 1>&2; exit 1; }
+
+while getopts ":i:o:j:" x; do
+    case "${x}" in
+        i)
+            input=${OPTARG}
+            ;;
+        o)
+            output=${OPTARG}
+            ;;
+        j)
+            json_input=${OPTARG}
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+if [ -z "${input}" ] || [ -z "${output}" ] || [ -z "${json_input}" ]; then
+    usage
+fi
+
 
 # Copy the json files to the intermediate directory
-cp /data/inputs/*.json /data/json_inputs/
+cp ${input}/*.json ${json_input}
 
 # Convert parquet to jsons
-python3 cosmos_integration.py -o /data/json_inputs /data/inputs
+python3 cosmos_integration.py -o ${json_input} ${input}
 
 # Run the TR pipeline
-java -jar target/scala-2.12/skema_text_reading-assembly-0.1.0-SNAPSHOT.jar org.ml4ai.skema.text_reading.apps.AnnotateCosmosJsonFiles -o /data/outputs /data/json_inputs
+java -jar target/scala-2.12/skema_text_reading-assembly-0.1.0-SNAPSHOT.jar org.ml4ai.skema.text_reading.apps.AnnotateCosmosJsonFiles -o ${output} ${json_input}


### PR DESCRIPTION
Right now the paths are hardcoded. I am making the script more flexible by taking these as arguments because input and output files are copied in a scratch directory in the ht condor cluster.