### PR TITLE
Build and publish project docker images to lumai dockerhub namespace

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,8 +21,9 @@ jobs:
     - name: generate short commit hash
       id: sha
       run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-  docker:
-    name: "docker images"
+
+  python:
+    name: "docker image for python components"
     needs: setup
     env:
       ORG: "lumai"
@@ -85,6 +86,39 @@ jobs:
         push: true
         tags: ${{ env.ORG }}/${{ env.IMAGE_NAME }}:latest,${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ needs.setup.outputs.sha_short }}
 
+  rust:
+    name: "docker image for rust components"
+    needs: setup
+    env:
+      ORG: "lumai"
+    runs-on: ubuntu-latest
+    steps:
+    # Setup docker
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    # for multi-arch builds (ex. ARM 64)
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+    # - name: Prepare buildx builder
+    #   run: |
+    #     docker buildx create --use --name "multiarch-builder" --platform linux/amd64,linux/arm64 --driver "docker-container"
+    - name: Inspect builder
+      run: |
+        echo "Name:      ${{ steps.buildx.outputs.name }}"
+        echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+        echo "Status:    ${{ steps.buildx.outputs.status }}"
+        echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+        echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
+    # Checkout code
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Login to DockerHub
+      uses: docker/login-action@v2 
+      with:
+        username: ${{ secrets.LUM_ASKEM_DOCKERHUB_USERNAME }}
+        password: ${{ secrets.LUM_ASKEM_DOCKERHUB_TOKEN }}
+
     ########################################
     # lumai/askem-skema-rs
     ########################################
@@ -116,6 +150,39 @@ jobs:
         push: true
         tags: ${{ env.ORG }}/${{ env.IMAGE_NAME }}:latest,${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ needs.setup.outputs.sha_short }}
 
+  text_reading:
+    name: "docker image for text reading component"
+    needs: setup
+    env:
+      ORG: "lumai"
+    runs-on: ubuntu-latest
+    steps:
+    # Setup docker
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    # for multi-arch builds (ex. ARM 64)
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+    # - name: Prepare buildx builder
+    #   run: |
+    #     docker buildx create --use --name "multiarch-builder" --platform linux/amd64,linux/arm64 --driver "docker-container"
+    - name: Inspect builder
+      run: |
+        echo "Name:      ${{ steps.buildx.outputs.name }}"
+        echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+        echo "Status:    ${{ steps.buildx.outputs.status }}"
+        echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+        echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
+    # Checkout code
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Login to DockerHub
+      uses: docker/login-action@v2 
+      with:
+        username: ${{ secrets.LUM_ASKEM_DOCKERHUB_USERNAME }}
+        password: ${{ secrets.LUM_ASKEM_DOCKERHUB_TOKEN }}
+
     ########################################
     # lumai/askem-skema-text-reading
     ########################################
@@ -144,6 +211,40 @@ jobs:
         platforms: linux/amd64
         push: true
         tags: ${{ env.ORG }}/${{ env.IMAGE_NAME }}:latest,${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ needs.setup.outputs.sha_short }}
+
+
+  image_to_mml:
+    name: "docker image for img2mml component"
+    needs: setup
+    env:
+      ORG: "lumai"
+    runs-on: ubuntu-latest
+    steps:
+    # Setup docker
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    # for multi-arch builds (ex. ARM 64)
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+    # - name: Prepare buildx builder
+    #   run: |
+    #     docker buildx create --use --name "multiarch-builder" --platform linux/amd64,linux/arm64 --driver "docker-container"
+    - name: Inspect builder
+      run: |
+        echo "Name:      ${{ steps.buildx.outputs.name }}"
+        echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+        echo "Status:    ${{ steps.buildx.outputs.status }}"
+        echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+        echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
+    # Checkout code
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Login to DockerHub
+      uses: docker/login-action@v2 
+      with:
+        username: ${{ secrets.LUM_ASKEM_DOCKERHUB_USERNAME }}
+        password: ${{ secrets.LUM_ASKEM_DOCKERHUB_TOKEN }}
 
     ########################################
     # lumai/askem-skema-img2mml

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,177 @@
+name: SKEMA docker
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# builds and publishes docker images for the default branch.
+# images are tagged with short commit hash and latest.
+jobs:
+  setup:
+    name: setup
+    runs-on: ubuntu-latest
+    outputs:
+      sha_short: ${{ steps.sha.outputs.sha_short }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    # FIXME: this is deprecated
+    - name: generate short commit hash
+      id: sha
+      run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+  docker:
+    name: "docker images"
+    needs: setup
+    env:
+      ORG: "lumai"
+    runs-on: ubuntu-latest
+    steps:
+    # Setup docker
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    # for multi-arch builds (ex. ARM 64)
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+    # - name: Prepare buildx builder
+    #   run: |
+    #     docker buildx create --use --name "multiarch-builder" --platform linux/amd64,linux/arm64 --driver "docker-container"
+    - name: Inspect builder
+      run: |
+        echo "Name:      ${{ steps.buildx.outputs.name }}"
+        echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+        echo "Status:    ${{ steps.buildx.outputs.status }}"
+        echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+        echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
+    # Checkout code
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Login to DockerHub
+      uses: docker/login-action@v2 
+      with:
+        username: ${{ secrets.LUM_ASKEM_DOCKERHUB_USERNAME }}
+        password: ${{ secrets.LUM_ASKEM_DOCKERHUB_TOKEN }}
+
+    ########################################
+    # lumai/askem-skema-py
+    ########################################
+    # build and tag image
+    - name: "build and tag `lumai/askem-skema-py` image"
+      env:
+        IMAGE_NAME: "lumai/askem-skema-py"
+      # see https://github.com/docker/build-push-action
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: "Dockerfile.skema-py"
+        platforms: linux/amd64
+        push: false
+        tags: ${{ env.ORG }}/$IMAGE_NAME:latest,${{ env.ORG }}/$IMAGE_NAME:${{ needs.setup.outputs.sha_short }}
+
+    # build, tag, and publish image
+    # NOTE: this will *not* rebuild the image, but rather utilize the cache from the prior step
+    - name: "build, tag, and publish `lumai/askem-skema-py` image"
+      if: github.ref == 'refs/heads/main'
+      env:
+        IMAGE_NAME: "lumai/askem-skema-py"
+      # see https://github.com/docker/build-push-action
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: "Dockerfile.skema-py"
+        platforms: linux/amd64
+        push: true
+        tags: ${{ env.ORG }}/$IMAGE_NAME:latest,${{ env.ORG }}/$IMAGE_NAME:${{ needs.setup.outputs.sha_short }}
+
+    ########################################
+    # lumai/askem-skema-rs
+    ########################################
+    # build and tag image
+    - name: "build and tag `lumai/askem-skema-rs` image"
+      env:
+        IMAGE_NAME: "lumai/askem-skema-rs"
+      # see https://github.com/docker/build-push-action
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: "Dockerfile.skema-rs"
+        platforms: linux/amd64
+        push: false
+        tags: ${{ env.ORG }}/$IMAGE_NAME:latest,${{ env.ORG }}/$IMAGE_NAME:${{ needs.setup.outputs.sha_short }}
+
+    # build, tag, and publish image
+    # NOTE: this will *not* rebuild the image, but rather utilize the cache from the prior step
+    - name: "build, tag, and publish `lumai/askem-skema-rs` image"
+      if: github.ref == 'refs/heads/main'
+      env:
+        IMAGE_NAME: "lumai/askem-skema-rs"
+      # see https://github.com/docker/build-push-action
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: "Dockerfile.skema-rs"
+        platforms: linux/amd64
+        push: true
+        tags: ${{ env.ORG }}/$IMAGE_NAME:latest,${{ env.ORG }}/$IMAGE_NAME:${{ needs.setup.outputs.sha_short }}
+
+    ########################################
+    # lumai/askem-skema-text-reading
+    ########################################
+    # build and tag image
+    - name: "build and tag `lumai/askem-skema-text-reading` image"
+      env:
+        IMAGE_NAME: "lumai/askem-skema-text-reading"
+      # see https://github.com/docker/build-push-action
+      uses: docker/build-push-action@v4
+      with:
+        context: ./skema/text_reading/text_reading
+        platforms: linux/amd64
+        push: false
+        tags: ${{ env.ORG }}/$IMAGE_NAME:latest,${{ env.ORG }}/$IMAGE_NAME:${{ needs.setup.outputs.sha_short }}
+
+    # build, tag, and publish image
+    # NOTE: this will *not* rebuild the image, but rather utilize the cache from the prior step
+    - name: "build, tag, and publish `lumai/askem-skema-text-reading` image"
+      if: github.ref == 'refs/heads/main'
+      env:
+        IMAGE_NAME: "lumai/askem-skema-text-reading"
+      # see https://github.com/docker/build-push-action
+      uses: docker/build-push-action@v4
+      with:
+        context: ./skema/text_reading/text_reading
+        platforms: linux/amd64
+        push: true
+        tags: ${{ env.ORG }}/$IMAGE_NAME:latest,${{ env.ORG }}/$IMAGE_NAME:${{ needs.setup.outputs.sha_short }}
+
+    ########################################
+    # lumai/askem-skema-img2mml
+    ########################################
+    # build and tag image
+    - name: "build and tag `lumai/askem-skema-img2mml` image"
+      env:
+        IMAGE_NAME: "lumai/askem-skema-img2mml"
+      # see https://github.com/docker/build-push-action
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: "Dockerfile.img2mml"
+        platforms: linux/amd64
+        push: false
+        tags: ${{ env.ORG }}/$IMAGE_NAME:latest,${{ env.ORG }}/$IMAGE_NAME:${{ needs.setup.outputs.sha_short }}
+
+    # build, tag, and publish image
+    # NOTE: this will *not* rebuild the image, but rather utilize the cache from the prior step
+    - name: "build, tag, and publish `lumai/askem-skema-img2mml` image"
+      if: github.ref == 'refs/heads/main'
+      env:
+        IMAGE_NAME: "lumai/askem-skema-img2mml"
+      # see https://github.com/docker/build-push-action
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: "Dockerfile.img2mml"
+        platforms: linux/amd64
+        push: true
+        tags: ${{ env.ORG }}/$IMAGE_NAME:latest,${{ env.ORG }}/$IMAGE_NAME:${{ needs.setup.outputs.sha_short }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,7 +68,7 @@ jobs:
         file: "Dockerfile.skema-py"
         platforms: linux/amd64
         push: false
-        tags: ${{ env.ORG }}/$IMAGE_NAME:latest,${{ env.ORG }}/$IMAGE_NAME:${{ needs.setup.outputs.sha_short }}
+        tags: ${{ env.ORG }}/${{ env.IMAGE_NAME }}:latest,${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ needs.setup.outputs.sha_short }}
 
     # build, tag, and publish image
     # NOTE: this will *not* rebuild the image, but rather utilize the cache from the prior step
@@ -83,7 +83,7 @@ jobs:
         file: "Dockerfile.skema-py"
         platforms: linux/amd64
         push: true
-        tags: ${{ env.ORG }}/$IMAGE_NAME:latest,${{ env.ORG }}/$IMAGE_NAME:${{ needs.setup.outputs.sha_short }}
+        tags: ${{ env.ORG }}/${{ env.IMAGE_NAME }}:latest,${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ needs.setup.outputs.sha_short }}
 
     ########################################
     # lumai/askem-skema-rs
@@ -99,7 +99,7 @@ jobs:
         file: "Dockerfile.skema-rs"
         platforms: linux/amd64
         push: false
-        tags: ${{ env.ORG }}/$IMAGE_NAME:latest,${{ env.ORG }}/$IMAGE_NAME:${{ needs.setup.outputs.sha_short }}
+        tags: ${{ env.ORG }}/${{ env.IMAGE_NAME }}:latest,${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ needs.setup.outputs.sha_short }}
 
     # build, tag, and publish image
     # NOTE: this will *not* rebuild the image, but rather utilize the cache from the prior step
@@ -114,7 +114,7 @@ jobs:
         file: "Dockerfile.skema-rs"
         platforms: linux/amd64
         push: true
-        tags: ${{ env.ORG }}/$IMAGE_NAME:latest,${{ env.ORG }}/$IMAGE_NAME:${{ needs.setup.outputs.sha_short }}
+        tags: ${{ env.ORG }}/${{ env.IMAGE_NAME }}:latest,${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ needs.setup.outputs.sha_short }}
 
     ########################################
     # lumai/askem-skema-text-reading
@@ -129,7 +129,7 @@ jobs:
         context: ./skema/text_reading/text_reading
         platforms: linux/amd64
         push: false
-        tags: ${{ env.ORG }}/$IMAGE_NAME:latest,${{ env.ORG }}/$IMAGE_NAME:${{ needs.setup.outputs.sha_short }}
+        tags: ${{ env.ORG }}/${{ env.IMAGE_NAME }}:latest,${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ needs.setup.outputs.sha_short }}
 
     # build, tag, and publish image
     # NOTE: this will *not* rebuild the image, but rather utilize the cache from the prior step
@@ -143,7 +143,7 @@ jobs:
         context: ./skema/text_reading/text_reading
         platforms: linux/amd64
         push: true
-        tags: ${{ env.ORG }}/$IMAGE_NAME:latest,${{ env.ORG }}/$IMAGE_NAME:${{ needs.setup.outputs.sha_short }}
+        tags: ${{ env.ORG }}/${{ env.IMAGE_NAME }}:latest,${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ needs.setup.outputs.sha_short }}
 
     ########################################
     # lumai/askem-skema-img2mml
@@ -159,7 +159,7 @@ jobs:
         file: "Dockerfile.img2mml"
         platforms: linux/amd64
         push: false
-        tags: ${{ env.ORG }}/$IMAGE_NAME:latest,${{ env.ORG }}/$IMAGE_NAME:${{ needs.setup.outputs.sha_short }}
+        tags: ${{ env.ORG }}/${{ env.IMAGE_NAME }}:latest,${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ needs.setup.outputs.sha_short }}
 
     # build, tag, and publish image
     # NOTE: this will *not* rebuild the image, but rather utilize the cache from the prior step
@@ -174,4 +174,4 @@ jobs:
         file: "Dockerfile.img2mml"
         platforms: linux/amd64
         push: true
-        tags: ${{ env.ORG }}/$IMAGE_NAME:latest,${{ env.ORG }}/$IMAGE_NAME:${{ needs.setup.outputs.sha_short }}
+        tags: ${{ env.ORG }}/${{ env.IMAGE_NAME }}:latest,${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ needs.setup.outputs.sha_short }}


### PR DESCRIPTION
This GitHub Action is intended to build the following images whenever a PR is opened:

- `lumai/askem-skema-py` (contains program analysis, moviz, etc. components)
- `lumai/askem-skema-rs`
- `lumai/askem-skema-text-reading`
- `lumai/askem-skema-img2mml`

Any push (including a merged PR) to `main` will publish those four images to public repos on Dockerhub.  Each image will be tagged with a) `latest` and b) its short Git commit hash.


Resolves #221 