### PR TITLE
[docker] Build, tag, and publish images whenever a git tag is pushed

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,30 +3,18 @@ name: SKEMA docker
 on:
   push:
     branches: [main]
+    tags:
+      - "**"
   pull_request:
     branches: [main]
+  release:
+    types: [published]
 
 # builds and publishes docker images for the default branch.
-# images are tagged with short commit hash and latest.
+# images are tagged with short commit hash, latest, and any tags.
 jobs:
-  setup:
-    name: setup
-    runs-on: ubuntu-latest
-    outputs:
-      sha_short: ${{ steps.sha.outputs.sha_short }}
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-    # FIXME: this is deprecated
-    - name: generate short commit hash
-      id: sha
-      run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-
   python:
     name: "docker image for python components"
-    needs: setup
-    env:
-      ORG: "lumai"
     runs-on: ubuntu-latest
     steps:
     # Setup docker
@@ -65,39 +53,33 @@ jobs:
     ########################################
     # lumai/askem-skema-py
     ########################################
-    # build and tag image
-    - name: "build and tag `lumai/askem-skema-py` image"
-      env:
-        IMAGE_NAME: "askem-skema-py"
-      # see https://github.com/docker/build-push-action
-      uses: docker/build-push-action@v4
+    - name: Tags for image
+      id: tags
+      # see https://github.com/docker/metadata-action
+      uses: docker/metadata-action@v4
       with:
-        context: .
-        file: "Dockerfile.skema-py"
-        platforms: linux/amd64
-        push: false
-        tags: ${{ env.ORG }}/${{ env.IMAGE_NAME }}:latest,${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ needs.setup.outputs.sha_short }}
+        images: lumai/askem-skema-py
+        tags: |
+          # version
+          type=semver,pattern={{version}}
+          # other tags
+          type=ref,event=tag
+          # short commit hash
+          type=sha
 
-    # build, tag, and publish image
-    # NOTE: this will *not* rebuild the image, but rather utilize the cache from the prior step
-    - name: "build, tag, and publish `lumai/askem-skema-py` image"
-      if: github.ref == 'refs/heads/main'
-      env:
-        IMAGE_NAME: "askem-skema-py"
+    - name: Build and push image
       # see https://github.com/docker/build-push-action
       uses: docker/build-push-action@v4
       with:
         context: .
         file: "Dockerfile.skema-py"
         platforms: linux/amd64
-        push: true
-        tags: ${{ env.ORG }}/${{ env.IMAGE_NAME }}:latest,${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ needs.setup.outputs.sha_short }}
+        push: ${{ github.event_name != 'pull_request' }}
+        # references `tags` step in steps for current job
+        tags: ${{ steps.tags.outputs.tags }}
 
   rust:
     name: "docker image for rust components"
-    needs: setup
-    env:
-      ORG: "lumai"
     runs-on: ubuntu-latest
     steps:
     # Setup docker
@@ -136,39 +118,33 @@ jobs:
     ########################################
     # lumai/askem-skema-rs
     ########################################
-    # build and tag image
-    - name: "build and tag `lumai/askem-skema-rs` image"
-      env:
-        IMAGE_NAME: "askem-skema-rs"
-      # see https://github.com/docker/build-push-action
-      uses: docker/build-push-action@v4
+    - name: Tags for image
+      id: tags
+      # see https://github.com/docker/metadata-action
+      uses: docker/metadata-action@v4
       with:
-        context: .
-        file: "Dockerfile.skema-rs"
-        platforms: linux/amd64
-        push: false
-        tags: ${{ env.ORG }}/${{ env.IMAGE_NAME }}:latest,${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ needs.setup.outputs.sha_short }}
+        images: lumai/askem-skema-rs
+        tags: |
+          # version
+          type=semver,pattern={{version}}
+          # other tags
+          type=ref,event=tag
+          # short commit hash
+          type=sha
 
-    # build, tag, and publish image
-    # NOTE: this will *not* rebuild the image, but rather utilize the cache from the prior step
-    - name: "build, tag, and publish `lumai/askem-skema-rs` image"
-      if: github.ref == 'refs/heads/main'
-      env:
-        IMAGE_NAME: "askem-skema-rs"
+    - name: Build and push image
       # see https://github.com/docker/build-push-action
       uses: docker/build-push-action@v4
       with:
         context: .
         file: "Dockerfile.skema-rs"
         platforms: linux/amd64
-        push: true
-        tags: ${{ env.ORG }}/${{ env.IMAGE_NAME }}:latest,${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ needs.setup.outputs.sha_short }}
+        push: ${{ github.event_name != 'pull_request' }}
+        # references `tags` step in steps for current job
+        tags: ${{ steps.tags.outputs.tags }}
 
   text_reading:
     name: "docker image for text reading component"
-    needs: setup
-    env:
-      ORG: "lumai"
     runs-on: ubuntu-latest
     steps:
     # Setup docker
@@ -207,38 +183,32 @@ jobs:
     ########################################
     # lumai/askem-skema-text-reading
     ########################################
-    # build and tag image
-    - name: "build and tag `lumai/askem-skema-text-reading` image"
-      env:
-        IMAGE_NAME: "askem-skema-text-reading"
+    - name: Tags for image
+      id: tags
+      # see https://github.com/docker/metadata-action
+      uses: docker/metadata-action@v4
+      with:
+        images: lumai/askem-skema-text-reading
+        tags: |
+          # version
+          type=semver,pattern={{version}}
+          # other tags
+          type=ref,event=tag
+          # short commit hash
+          type=sha
+
+    - name: Build and push image
       # see https://github.com/docker/build-push-action
       uses: docker/build-push-action@v4
       with:
         context: ./skema/text_reading/text_reading
         platforms: linux/amd64
-        push: false
-        tags: ${{ env.ORG }}/${{ env.IMAGE_NAME }}:latest,${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ needs.setup.outputs.sha_short }}
-
-    # build, tag, and publish image
-    # NOTE: this will *not* rebuild the image, but rather utilize the cache from the prior step
-    - name: "build, tag, and publish `lumai/askem-skema-text-reading` image"
-      if: github.ref == 'refs/heads/main'
-      env:
-        IMAGE_NAME: "askem-skema-text-reading"
-      # see https://github.com/docker/build-push-action
-      uses: docker/build-push-action@v4
-      with:
-        context: ./skema/text_reading/text_reading
-        platforms: linux/amd64
-        push: true
-        tags: ${{ env.ORG }}/${{ env.IMAGE_NAME }}:latest,${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ needs.setup.outputs.sha_short }}
-
+        push: ${{ github.event_name != 'pull_request' }}
+        # references `tags` step in steps for current job
+        tags: ${{ steps.tags.outputs.tags }}
 
   image_to_mml:
     name: "docker image for img2mml component"
-    needs: setup
-    env:
-      ORG: "lumai"
     runs-on: ubuntu-latest
     steps:
     # Setup docker
@@ -277,30 +247,27 @@ jobs:
     ########################################
     # lumai/askem-skema-img2mml
     ########################################
-    # build and tag image
-    - name: "build and tag `lumai/askem-skema-img2mml` image"
-      env:
-        IMAGE_NAME: "askem-skema-img2mml"
-      # see https://github.com/docker/build-push-action
-      uses: docker/build-push-action@v4
+    - name: Tags for image
+      id: tags
+      # see https://github.com/docker/metadata-action
+      uses: docker/metadata-action@v4
       with:
-        context: .
-        file: "Dockerfile.img2mml"
-        platforms: linux/amd64
-        push: false
-        tags: ${{ env.ORG }}/${{ env.IMAGE_NAME }}:latest,${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ needs.setup.outputs.sha_short }}
+        images: lumai/askem-skema-img2mml
+        tags: |
+          # version
+          type=semver,pattern={{version}}
+          # other tags
+          type=ref,event=tag
+          # short commit hash
+          type=sha
 
-    # build, tag, and publish image
-    # NOTE: this will *not* rebuild the image, but rather utilize the cache from the prior step
-    - name: "build, tag, and publish `lumai/askem-skema-img2mml` image"
-      if: github.ref == 'refs/heads/main'
-      env:
-        IMAGE_NAME: "askem-skema-img2mml"
+    - name: Build and push image
       # see https://github.com/docker/build-push-action
       uses: docker/build-push-action@v4
       with:
         context: .
         file: "Dockerfile.img2mml"
         platforms: linux/amd64
-        push: true
-        tags: ${{ env.ORG }}/${{ env.IMAGE_NAME }}:latest,${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ needs.setup.outputs.sha_short }}
+        push: ${{ github.event_name != 'pull_request' }}
+        # references `tags` step in steps for current job
+        tags: ${{ steps.tags.outputs.tags }}


### PR DESCRIPTION
Builds and publishes docker images for the default branch.  Images are tagged with short commit hash, latest, and any Git tags.

Resolves #228.
