### PR TITLE
Ensure `latest` tag is always published

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,6 +60,8 @@ jobs:
       with:
         images: lumai/askem-skema-py
         tags: |
+          # latest
+          type=raw,value=latest
           # version
           type=semver,pattern={{version}}
           # other tags
@@ -125,6 +127,8 @@ jobs:
       with:
         images: lumai/askem-skema-rs
         tags: |
+          # latest
+          type=raw,value=latest
           # version
           type=semver,pattern={{version}}
           # other tags
@@ -190,6 +194,8 @@ jobs:
       with:
         images: lumai/askem-skema-text-reading
         tags: |
+          # latest
+          type=raw,value=latest
           # version
           type=semver,pattern={{version}}
           # other tags
@@ -254,6 +260,8 @@ jobs:
       with:
         images: lumai/askem-skema-img2mml
         tags: |
+          # latest
+          type=raw,value=latest
           # version
           type=semver,pattern={{version}}
           # other tags


### PR DESCRIPTION
This PR ensures that the most recent image published to Docker Hub is tagged with `latest`.