### PR TITLE
Network from environment

### DIFF
--- a/skema/img2mml/api.py
+++ b/skema/img2mml/api.py
@@ -42,9 +42,9 @@ def get_mathml_from_latex(eqn) -> str:
     """Read a LaTeX equation string and convert it to presentation MathML"""
 
     # Define the webservice address from the MathJAX service
+    host = os.environ.get('SKEMA_HOST', '127.0.0.1')
     port = os.environ.get('SKEMA_MATHJAX_PORT', 8031)
-    network = os.environ.get('SKEMA_NETWORK', '127.0.0.1')
-    webservice = network + ':' + port
+    webservice = host + ':' + port
     print('Connecting to ' + webservice)
 
     # Translate and save each LaTeX string using the NodeJS service for MathJax

--- a/skema/img2mml/api.py
+++ b/skema/img2mml/api.py
@@ -5,7 +5,6 @@ import requests
 import re
 from skema.img2mml.translate import convert_to_torch_tensor, render_mml
 
-PORT = os.environ.get('MATHJAX_PORT', 8031)
 
 def get_mathml_from_bytes(data: bytes):
     # convert png image to tensor
@@ -43,7 +42,11 @@ def get_mathml_from_latex(eqn) -> str:
     """Read a LaTeX equation string and convert it to presentation MathML"""
 
     # Define the webservice address from the MathJAX service
-    webservice = "http://localhost:" + str(PORT)
+    port = os.environ.get('SKEMA_MATHJAX_PORT', 8031)
+    network = os.environ.get('SKEMA_NETWORK', '127.0.0.1')
+    webservice = network + ':' + port
+    print('Connecting to ' + webservice)
+
     # Translate and save each LaTeX string using the NodeJS service for MathJax
     res = requests.post(
         f"{webservice}/tex2mml",

--- a/skema/img2mml/api.py
+++ b/skema/img2mml/api.py
@@ -1,10 +1,11 @@
 import json
+import os
 from pathlib import Path
 import requests
 import re
 from skema.img2mml.translate import convert_to_torch_tensor, render_mml
 
-PORT = 8031
+PORT = os.environ.get('MATHJAX_PORT', 8031)
 
 def get_mathml_from_bytes(data: bytes):
     # convert png image to tensor

--- a/skema/img2mml/data_generation/mathjax_server.js
+++ b/skema/img2mml/data_generation/mathjax_server.js
@@ -1,7 +1,11 @@
 const express = require('express');
 const mjAPI = require("mathjax-node");
 const _ = require('lodash');
-const PORT = 8031;
+var PORT = process.env.MATHJAX_PORT;
+if(port == undefined) {
+   port = "8031";
+}
+
 
 // ==== Initialize the express server ==========================================
 var app = express();

--- a/skema/img2mml/data_generation/mathjax_server.js
+++ b/skema/img2mml/data_generation/mathjax_server.js
@@ -1,9 +1,9 @@
 const express = require('express');
 const mjAPI = require("mathjax-node");
 const _ = require('lodash');
-var PORT = process.env.MATHJAX_PORT;
-if(port == undefined) {
-   port = "8031";
+var PORT = process.env.SKEMA_MATHJAX_PORT;
+if(PORT == undefined) {
+   PORT = "8031";
 }
 
 

--- a/skema/img2mml/data_generation/mathjax_server.js
+++ b/skema/img2mml/data_generation/mathjax_server.js
@@ -1,10 +1,7 @@
 const express = require('express');
 const mjAPI = require("mathjax-node");
 const _ = require('lodash');
-var PORT = process.env.SKEMA_MATHJAX_PORT;
-if(PORT == undefined) {
-   PORT = "8031";
-}
+
 
 
 // ==== Initialize the express server ==========================================
@@ -90,9 +87,32 @@ app.get('/restart', function (req, res) {
     res.send("MathJax service restarted");
 });
 
+function port() {
+    try {
+        var port = process.env.SKEMA_MATHJAX_PORT
+        if(port == undefined) {
+            port = "8031";
+        }
+        return port;
+    } catch(err) {
+        return "8031";
+    }
+}
+
+function host() {
+    try {
+        var host = process.env.SKEMA_HOST
+        if(host == undefined) {
+            return "127.0.0.1";
+        }
+        return host;
+    } catch(err) {
+        return "127.0.0.1";
+    }
+}
 
 // Start the express application server
-var server = app.listen(PORT, function () {
-    var port = server.address().port
-    console.log("MathJax server listening at http://localhost:%s", port)
+var server = app.listen(port(), host(), function(){
+    console.log("MathJax server listening at %s:%s", server.address().address, server.address().port);
 });
+


### PR DESCRIPTION
The host and port for the mathjax service are read from environment:

- SKEMA_HOST
- SKEMA_MATHJAX_PORT

If not found, these are set to '127.0.0.1' and '8031' respectively.

