### PR TITLE
index page for test coverage reports

### DIFF
--- a/docs/coverage/index.md
+++ b/docs/coverage/index.md
@@ -1,0 +1,2 @@
+# Coverage reports
+[Coverage for Python library](./python)


### PR DESCRIPTION
Test coverage reports for Python are now published to our project site: https://ml4ai.github.io/skema/coverage/python/index.html

Because of an oversight in the project .gitignore, https://ml4ai.github.io/skema/coverage/  is returning a 404.  This PR ensures https://ml4ai.github.io/skema/coverage/ resolves to an index.html.