### PR TITLE
Added endpoint for extracting comments from zipfile

### DIFF
--- a/skema/skema-rs/Cargo.lock
+++ b/skema/skema-rs/Cargo.lock
@@ -49,13 +49,13 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "smallvec",
  "tokio",
  "tokio-util",
  "tracing",
- "zstd",
+ "zstd 0.12.3+zstd.1.5.2",
 ]
 
 [[package]]
@@ -190,6 +190,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aes"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +287,12 @@ name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bindgen"
@@ -376,6 +393,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +450,16 @@ dependencies = [
  "time 0.1.45",
  "wasm-bindgen",
  "winapi",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -505,13 +553,19 @@ dependencies = [
  "log",
  "nom 7.1.3",
  "nom_locate",
- "pretty_env_logger",
+ "pretty_env_logger 0.4.0",
  "regex",
  "serde",
  "serde_json",
  "strum_macros",
  "walkdir",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "convert_case"
@@ -638,6 +692,7 @@ checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -702,6 +757,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime 2.1.0",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +820,12 @@ checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures-core"
@@ -866,6 +940,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "html-escape"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,6 +1038,15 @@ dependencies = [
  "autocfg",
  "hashbrown",
  "serde",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1082,12 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "maplit"
@@ -1254,10 +1343,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
+]
 
 [[package]]
 name = "peeking_take_while"
@@ -1316,6 +1428,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_env_logger"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
+dependencies = [
+ "env_logger 0.10.0",
+ "log",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,13 +1487,26 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1381,8 +1516,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1391,6 +1541,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1429,6 +1588,15 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "rsmgclient"
@@ -1689,16 +1857,20 @@ dependencies = [
  "actix-web",
  "clap 4.1.11",
  "comment_extraction",
+ "log",
  "mathml",
  "petgraph",
+ "pretty_env_logger 0.5.0",
  "rsmgclient",
  "schemars",
  "serde",
  "serde_json",
  "strum",
  "strum_macros",
+ "tempdir",
  "utoipa",
  "utoipa-swagger-ui",
+ "zip",
 ]
 
 [[package]]
@@ -1758,6 +1930,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,6 +1944,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
 ]
 
 [[package]]
@@ -2216,14 +2404,31 @@ checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "zip"
-version = "0.6.4"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0445d0fbc924bb93539b4316c11afb121ea39296f99a3c4c9edad09e3658cdef"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
 dependencies = [
+ "aes",
  "byteorder",
+ "bzip2",
+ "constant_time_eq",
  "crc32fast",
  "crossbeam-utils",
  "flate2",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time 0.3.20",
+ "zstd 0.11.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe 5.0.2+zstd.1.5.2",
 ]
 
 [[package]]
@@ -2232,7 +2437,17 @@ version = "0.12.3+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76eea132fb024e0e13fd9c2f5d5d595d8a967aa72382ac2f9d39fcc95afd0806"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 6.0.4+zstd.1.5.4",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
 ]
 
 [[package]]

--- a/skema/skema-rs/comment_extraction/src/bin/extract_comments.rs
+++ b/skema/skema-rs/comment_extraction/src/bin/extract_comments.rs
@@ -1,29 +1,14 @@
 //! Program to get comments from a source code file.
 
-use clap::{Parser, ValueEnum};
+use clap::Parser;
+use comment_extraction::{
+    conventions,
+    conventions::Convention,
+    extraction::{extract_comments_from_directory, extract_comments_from_file},
+};
 use std::{collections::HashSet, fs::read_to_string};
 
-use lazy_static::lazy_static;
 use serde_json as json;
-use std::path::Path;
-
-use comment_extraction::{
-    comments::Comment,
-    conventions::dssat::get_comments as get_dssat_comments,
-    languages::{
-        cpp::get_comments as get_cpp_comments, fortran::line_is_comment,
-        python::get_comments as get_python_comments,
-    },
-};
-
-/// Some codebases (e.g., the codebase for the DSSAT crop modeling
-/// system) follow a particular commenting convention. In such cases, we may want to handle the
-/// comment extraction differently in order to facilitate alignment with the literature. This enum
-/// contains the different conventions we handle.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, ValueEnum)]
-enum Convention {
-    DSSAT,
-}
 
 /// Command line arguments
 #[derive(Parser)]
@@ -36,107 +21,6 @@ struct Cli {
     convention: Option<Convention>,
 }
 
-/// Programming language
-#[derive(Debug)]
-enum Language {
-    /// Python
-    Python,
-
-    /// Fortran
-    Fortran,
-
-    /// C++ or C
-    CppOrC,
-
-    /// Other (unknown)
-    Other,
-}
-
-/// Infer language for the file in question.
-fn infer_language(filepath: &str) -> Language {
-    lazy_static! {
-        static ref FORTRAN_EXTENSIONS: HashSet<&'static str> =
-            HashSet::from(["f", "for", "F", "F70"]);
-        static ref CPP_C_EXTENSIONS: HashSet<&'static str> =
-            HashSet::from(["c", "cc", "cpp", "h", "hpp"]);
-    }
-
-    let extension = Path::new(filepath)
-        .extension()
-        .unwrap_or_else(|| panic!("Unable to get extension for {}!", filepath))
-        .to_str()
-        .expect("Unable to convert extension to a valid string!");
-    if FORTRAN_EXTENSIONS.contains(extension) {
-        Language::Fortran
-    } else if extension == "py" {
-        Language::Python
-    } else if CPP_C_EXTENSIONS.contains(extension) {
-        Language::CppOrC
-    } else {
-        Language::Other
-    }
-}
-
-/// Extract comments from file and return them.
-fn extract_comments_from_file(
-    filepath: &str,
-    convention: &Option<Convention>,
-) -> Result<String, &'static str> {
-    let language = infer_language(filepath);
-    let comments: String;
-    match language {
-        Language::Fortran => {
-            if let Some(Convention::DSSAT) = convention {
-                comments = json::to_string(&get_dssat_comments(filepath).unwrap()).unwrap();
-            } else {
-                let fortran = read_to_string(filepath).expect("Unable to read file");
-                let mut comment_vec = Vec::new();
-
-                for (num, line) in fortran.lines().enumerate() {
-                    if line_is_comment(line) {
-                        let comment = Comment {
-                            line_number: num + 1,
-                            contents: line.trim().to_string(),
-                        };
-                        comment_vec.push(comment);
-                    }
-                }
-                comments = json::to_string(&comment_vec).unwrap();
-            }
-        }
-        Language::Python => {
-            comments = json::to_string(&get_python_comments(filepath)).unwrap();
-        }
-        Language::CppOrC => {
-            comments = json::to_string(&get_cpp_comments(filepath)).unwrap();
-        }
-        Language::Other => return Err(
-            "File extension does not correspond to any of the ones the comment extractor handles.",
-        ),
-    }
-
-    Ok(comments)
-}
-
-/// Walk a directory recursively and extract comments from the files within it.
-fn extract_comments_from_directory(directory: &str, convention: &Option<Convention>) {
-    let mut comments = json::Value::default();
-    for entry in walkdir::WalkDir::new(directory)
-        .into_iter()
-        .filter_map(|e| e.ok())
-    {
-        let path = entry.path().to_str().unwrap();
-        let metadata = std::fs::metadata(path).unwrap();
-        if metadata.is_file() {
-            let file_comments = extract_comments_from_file(path, convention);
-            if let Ok(file_comments) = file_comments {
-                comments[path] = json::from_str(&file_comments).unwrap();
-            }
-        }
-    }
-    println!("{comments}");
-}
-
 fn main() {
     pretty_env_logger::init();
     let args = Cli::parse();
@@ -145,14 +29,15 @@ fn main() {
 
     let metadata = std::fs::metadata(input).unwrap();
     if metadata.is_file() {
-        // We use unwrap below since we want the program to complain loudly if only a single file
-        // is given as input and the comment extraction fails.
+        // We use unwrap below since we want the program to complain loudly and fail if only a
+        // single file is given as input and the comment extraction fails.
         // In contrast, when we extract comments from a directory, we do not want the program to
         // complain for every unprocessable file.
         let comments = extract_comments_from_file(input, convention).unwrap();
         println!("{comments}");
     } else if metadata.is_dir() {
-        extract_comments_from_directory(input, convention)
+        let comments = extract_comments_from_directory(input, convention);
+        println!("{comments}");
     }
 }
 
@@ -163,7 +48,7 @@ fn test_dssat_style_extraction() {
         json::from_str(&read_to_string("tests/data/chime_sir_output.json").unwrap()).unwrap();
     let comments: json::Value = json::from_str(
         &json::to_string(
-            &get_dssat_comments(
+            &conventions::dssat::get_comments(
                 "./../../../data/epidemiology/CHIME/CHIME_SIR_model/code/CHIME_SIR.for",
             )
             .unwrap(),

--- a/skema/skema-rs/comment_extraction/src/conventions.rs
+++ b/skema/skema-rs/comment_extraction/src/conventions.rs
@@ -1,1 +1,11 @@
+use clap::ValueEnum;
 pub mod dssat;
+
+/// Some codebases (e.g., the codebase for the DSSAT crop modeling
+/// system) follow a particular commenting convention. In such cases, we may want to handle the
+/// comment extraction differently in order to facilitate alignment with the literature. This enum
+/// contains the different conventions we handle.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, ValueEnum)]
+pub enum Convention {
+    DSSAT,
+}

--- a/skema/skema-rs/comment_extraction/src/extraction.rs
+++ b/skema/skema-rs/comment_extraction/src/extraction.rs
@@ -1,0 +1,117 @@
+use lazy_static::lazy_static;
+use serde_json as json;
+use std::{collections::HashSet, fs::read_to_string, path::Path};
+use walkdir;
+
+use crate::{
+    comments::Comment,
+    conventions::{dssat::get_comments as get_dssat_comments, Convention},
+    languages::{
+        cpp::get_comments as get_cpp_comments, fortran::line_is_comment,
+        python::get_comments as get_python_comments,
+    },
+};
+
+/// Programming language
+#[derive(Debug)]
+enum Language {
+    /// Python
+    Python,
+
+    /// Fortran
+    Fortran,
+
+    /// C++ or C
+    CppOrC,
+
+    /// Other (unknown)
+    Other,
+}
+
+/// Infer language for the file in question.
+fn infer_language(filepath: &str) -> Language {
+    lazy_static! {
+        static ref FORTRAN_EXTENSIONS: HashSet<&'static str> =
+            HashSet::from(["f", "for", "F", "F70"]);
+        static ref CPP_C_EXTENSIONS: HashSet<&'static str> =
+            HashSet::from(["c", "cc", "cpp", "h", "hpp"]);
+    }
+
+    let extension = Path::new(filepath)
+        .extension()
+        .unwrap_or_else(|| panic!("Unable to get extension for {}!", filepath))
+        .to_str()
+        .expect("Unable to convert extension to a valid string!");
+    if FORTRAN_EXTENSIONS.contains(extension) {
+        Language::Fortran
+    } else if extension == "py" {
+        Language::Python
+    } else if CPP_C_EXTENSIONS.contains(extension) {
+        Language::CppOrC
+    } else {
+        Language::Other
+    }
+}
+
+/// Extract comments from file and return them.
+pub fn extract_comments_from_file(
+    filepath: &str,
+    convention: &Option<Convention>,
+) -> Result<String, &'static str> {
+    let language = infer_language(filepath);
+    let comments: String;
+    match language {
+        Language::Fortran => {
+            if let Some(Convention::DSSAT) = convention {
+                comments = json::to_string(&get_dssat_comments(filepath).unwrap()).unwrap();
+            } else {
+                let fortran = read_to_string(filepath).expect("Unable to read file");
+                let mut comment_vec = Vec::new();
+
+                for (num, line) in fortran.lines().enumerate() {
+                    if line_is_comment(line) {
+                        let comment = Comment {
+                            line_number: num + 1,
+                            contents: line.trim().to_string(),
+                        };
+                        comment_vec.push(comment);
+                    }
+                }
+                comments = json::to_string(&comment_vec).unwrap();
+            }
+        }
+        Language::Python => {
+            comments = json::to_string(&get_python_comments(filepath)).unwrap();
+        }
+        Language::CppOrC => {
+            comments = json::to_string(&get_cpp_comments(filepath)).unwrap();
+        }
+        Language::Other => return Err(
+            "File extension does not correspond to any of the ones the comment extractor handles.",
+        ),
+    }
+
+    Ok(comments)
+}
+
+/// Walk a directory recursively and extract comments from the files within it.
+pub fn extract_comments_from_directory<P: AsRef<Path>>(
+    directory: P,
+    convention: &Option<Convention>,
+) -> json::Value {
+    let mut comments = json::Value::default();
+    for entry in walkdir::WalkDir::new(directory)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let path = entry.path().to_str().unwrap();
+        let metadata = std::fs::metadata(path).unwrap();
+        if metadata.is_file() {
+            let file_comments = extract_comments_from_file(path, convention);
+            if let Ok(file_comments) = file_comments {
+                comments[path] = json::from_str(&file_comments).unwrap();
+            }
+        }
+    }
+    comments
+}

--- a/skema/skema-rs/comment_extraction/src/lib.rs
+++ b/skema/skema-rs/comment_extraction/src/lib.rs
@@ -2,4 +2,5 @@
 
 pub mod comments;
 pub mod conventions;
+pub mod extraction;
 pub mod languages;

--- a/skema/skema-rs/skema/Cargo.toml
+++ b/skema/skema-rs/skema/Cargo.toml
@@ -22,3 +22,7 @@ petgraph = "0.6.2"
 clap = { version = "4.0.26", features = ["derive"] }
 utoipa-swagger-ui = { version = "3.0.2", features = ["actix-web"] }
 schemars = { version = "0.8.12" }
+tempdir = "0.3.7"
+log = "0.4.19"
+pretty_env_logger = "0.5.0"
+zip = "0.6.6"

--- a/skema/skema-rs/skema/src/bin/skema_service.rs
+++ b/skema/skema-rs/skema/src/bin/skema_service.rs
@@ -34,10 +34,13 @@ pub async fn ping() -> HttpResponse {
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+    pretty_env_logger::init();
+
     #[derive(OpenApi)]
     #[openapi(
         paths(
             comment_extraction::get_comments,
+            comment_extraction::get_comments_from_zipfile,
             skema::services::mathml::get_ast_graph,
             skema::services::mathml::get_math_exp_graph,
             skema::services::mathml::get_acset,
@@ -121,6 +124,7 @@ async fn main() -> std::io::Result<()> {
             }))
             .configure(gromet::configure())
             .service(comment_extraction::get_comments)
+            .service(comment_extraction::get_comments_from_zipfile)
             .service(skema::services::mathml::get_ast_graph)
             .service(skema::services::mathml::get_math_exp_graph)
             .service(skema::services::mathml::get_acset)

--- a/skema/skema-rs/skema/src/services/comment_extraction.rs
+++ b/skema/skema-rs/skema/src/services/comment_extraction.rs
@@ -76,7 +76,7 @@ impl CommentExtractionRequest {
         (status = 200, description = "Get comments", body = CommentExtractionResponse)
     )
 )]
-#[post("/get-comments")]
+#[post("/extract-comments")]
 pub async fn get_comments(payload: web::Json<CommentExtractionRequest>) -> HttpResponse {
     HttpResponse::Ok().json(web::Json(get_python_comments(&payload.code)))
 }
@@ -88,7 +88,7 @@ pub async fn get_comments(payload: web::Json<CommentExtractionRequest>) -> HttpR
         (status = 200, description = "Get comments from zipfile")
     )
 )]
-#[post("/get-comments-from-zipfile")]
+#[post("/extract-comments-from-zipfile")]
 pub async fn get_comments_from_zipfile(payload: web::Bytes) -> HttpResponse {
     debug!("Zip file received. Size: {} bytes", payload.len());
     let tmp_dir = TempDir::new("comment_extraction_input").unwrap();

--- a/skema/skema-rs/skema/src/services/comment_extraction.rs
+++ b/skema/skema-rs/skema/src/services/comment_extraction.rs
@@ -76,7 +76,7 @@ impl CommentExtractionRequest {
         (status = 200, description = "Get comments", body = CommentExtractionResponse)
     )
 )]
-#[get("/get_comments")]
+#[post("/get-comments")]
 pub async fn get_comments(payload: web::Json<CommentExtractionRequest>) -> HttpResponse {
     HttpResponse::Ok().json(web::Json(get_python_comments(&payload.code)))
 }

--- a/skema/skema-rs/skema/src/services/comment_extraction.rs
+++ b/skema/skema-rs/skema/src/services/comment_extraction.rs
@@ -1,11 +1,14 @@
 //! Comment extraction services
 
-use actix_web::{get, web, HttpResponse};
-use comment_extraction::comments::Comments;
+use actix_web::{get, post, web, HttpResponse};
+use comment_extraction::{comments::Comments, extraction::extract_comments_from_directory};
 use comment_extraction::languages::python::get_comments_from_string as get_python_comments;
 use serde::{Deserialize, Serialize};
 use utoipa;
 use utoipa::ToSchema;
+use std::{fs, io::Write};
+use log::debug;
+use tempdir::TempDir;
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub enum Language {
@@ -76,4 +79,33 @@ impl CommentExtractionRequest {
 #[get("/get_comments")]
 pub async fn get_comments(payload: web::Json<CommentExtractionRequest>) -> HttpResponse {
     HttpResponse::Ok().json(web::Json(get_python_comments(&payload.code)))
+}
+
+
+/// Get comments for a zipfile containing a directory of code
+#[utoipa::path(
+    responses(
+        (status = 200, description = "Get comments from zipfile")
+    )
+)]
+#[post("/get-comments-from-zipfile")]
+pub async fn get_comments_from_zipfile(payload: web::Bytes) -> HttpResponse {
+    debug!("Zip file received. Size: {} bytes", payload.len());
+    let tmp_dir = TempDir::new("comment_extraction_input").unwrap();
+    let file_path = tmp_dir.path().join("directory.zip");
+    //let file_path = "test.zip";
+    let mut f = fs::File::create(file_path.clone()).unwrap();
+    f.write_all(&payload).unwrap();
+    drop(f);
+
+    // Read zipfile
+    let file = fs::File::open(file_path).unwrap();
+    let mut archive = zip::ZipArchive::new(file).unwrap();
+    archive.extract(&tmp_dir).unwrap();
+    let comments = extract_comments_from_directory(&tmp_dir, &None);
+
+    tmp_dir.close().unwrap();
+
+    HttpResponse::Ok().json(web::Json(comments))
+    //HttpResponse::Ok().finish()
 }

--- a/skema/skema-rs/skema/src/services/comment_extraction.rs
+++ b/skema/skema-rs/skema/src/services/comment_extraction.rs
@@ -93,7 +93,6 @@ pub async fn get_comments_from_zipfile(payload: web::Bytes) -> HttpResponse {
     debug!("Zip file received. Size: {} bytes", payload.len());
     let tmp_dir = TempDir::new("comment_extraction_input").unwrap();
     let file_path = tmp_dir.path().join("directory.zip");
-    //let file_path = "test.zip";
     let mut f = fs::File::create(file_path.clone()).unwrap();
     f.write_all(&payload).unwrap();
     drop(f);
@@ -107,5 +106,4 @@ pub async fn get_comments_from_zipfile(payload: web::Bytes) -> HttpResponse {
     tmp_dir.close().unwrap();
 
     HttpResponse::Ok().json(web::Json(comments))
-    //HttpResponse::Ok().finish()
 }


### PR DESCRIPTION
This PR adds a REST API endpoint to the skema-rs service for extracting comments from a zipfile.

Example curl invocation:

```
curl -X POST localhost:8080/get-comments-from-zipfile --data-binary "@data.zip"
```