### PR TITLE
Correct return type for PA endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![](http://ci.kraken.sista.arizona.edu/api/badges/ml4ai/skema/status.svg)  
-![Docker lumai/askem-skema-py Image Version (latest by date)](https://img.shields.io/docker/v/lumai/askem-skema-py?sort=date&logo=docker&label=lumai%2Faskem-skema-py)  
-![Docker lumai/askem-skema-img2mml Image Version (latest by date)](https://img.shields.io/docker/v/lumai/askem-skema-img2mml?sort=date&logo=docker&label=lumai%2Faskem-skema-img2mml)  
-![Docker lumai/askem-skema-rs Image Version (latest by date)](https://img.shields.io/docker/v/lumai/askem-skema-rs?sort=date&logo=docker&label=lumai%2Faskem-skema-rs)  
-![Docker lumai/askem-skema-text-reading Image Version (latest by date)](https://img.shields.io/docker/v/lumai/askem-skema-text-reading?sort=date&logo=docker&label=lumai%2Faskem-skema-text-reading)
+[![Docker lumai/askem-skema-py Image Version (latest by date)](https://img.shields.io/docker/v/lumai/askem-skema-py?sort=date&logo=docker&label=lumai%2Faskem-skema-py)](https://hub.docker.com/r/lumai/askem-skema-py)  
+[![Docker lumai/askem-skema-img2mml Image Version (latest by date)](https://img.shields.io/docker/v/lumai/askem-skema-img2mml?sort=date&logo=docker&label=lumai%2Faskem-skema-img2mml)](https://hub.docker.com/r/lumai/askem-skema-img2mml)  
+[![Docker lumai/askem-skema-rs Image Version (latest by date)](https://img.shields.io/docker/v/lumai/askem-skema-rs?sort=date&logo=docker&label=lumai%2Faskem-skema-rs)](https://hub.docker.com/r/lumai/askem-skema-rs)  
+[![Docker lumai/askem-skema-text-reading Image Version (latest by date)](https://img.shields.io/docker/v/lumai/askem-skema-text-reading?sort=date&logo=docker&label=lumai%2Faskem-skema-text-reading)](https://hub.docker.com/r/lumai/askem-skema-text-reading)
 
 # SKEMA: Scientific Knowledge Extraction and Model Analysis
 

--- a/skema/skema_py/server.py
+++ b/skema/skema_py/server.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 from pathlib import Path
@@ -28,6 +29,7 @@ class System(BaseModel):
     root_name: Optional[str] = ""
 
 
+# FIXME: why does this return a a string?
 def system_to_gromet(system: System):
     """Convert a System to Gromet JSON"""
 
@@ -93,7 +95,8 @@ async def fn_given_filepaths(system: System):
     response = requests.post("http://0.0.0.0:8000/fn-given-filepaths", json=system)
     gromet_json = response.json()
     """
-    return system_to_gromet(system)
+    # FIXME: remove json.loads() wrapper after use of dictionary_to_gromet_json is addressed
+    return json.loads(system_to_gromet(system))
 
 
 @app.post(
@@ -138,7 +141,8 @@ async def root(zip_file: UploadFile = File()):
     system = System(
         files=files, blobs=blobs, system_name=system_name, root_name=root_name
     )
-    return system_to_gromet(system)
+    # FIXME: remove json.loads() wrapper after use of dictionary_to_gromet_json is addressed
+    return json.loads(system_to_gromet(system))
 
 
 @app.post(

--- a/skema/skema_py/server.py
+++ b/skema/skema_py/server.py
@@ -7,7 +7,7 @@ from io import BytesIO
 from zipfile import ZipFile
 from urllib.request import urlopen
 from fastapi import FastAPI, Body, File, UploadFile
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 import skema.skema_py.acsets
 import skema.skema_py.petris
@@ -23,10 +23,10 @@ class Ports(BaseModel):
 
 
 class System(BaseModel):
-    files: List[str] = []
-    blobs: List[str]
-    system_name: Optional[str] = ""
-    root_name: Optional[str] = ""
+    files: List[str] = Field(description="The file name corresponding to each entry in `blobs`", example=["example.py"])
+    blobs: List[str] = Field(decription="Contents of each file to be analyzed", example=["greet = lambda: print('howdy!')\ngreet()"])
+    system_name: Optional[str] = Field(default=None, decription="A model name to associate with the provided code", example="my-system")
+    root_name: Optional[str] = Field(default=None, decription="????", example=None)
 
 
 # FIXME: why does this return a a string?


### PR DESCRIPTION
The code2fn endpoints claim to return JSON, but actually return strings.  Rather than converting dictionaries to JSON-like strings, this PR delegates the process to FastAPI for predictable return types.