### PR TITLE
Gracefully handle optional fields in PA

### DIFF
--- a/skema/gromet/__init__.py
+++ b/skema/gromet/__init__.py
@@ -1,0 +1,3 @@
+GROMET_VERSION = "0.1.7"
+
+__all__ = ["GROMET_VERSION"]

--- a/skema/program_analysis/multi_file_ingester.py
+++ b/skema/program_analysis/multi_file_ingester.py
@@ -4,6 +4,7 @@ import glob
 import sys
 import os.path
 
+from skema.gromet import GROMET_VERSION
 from skema.gromet.fn import (
     GrometFNModuleCollection,
 )
@@ -44,7 +45,7 @@ def process_file_system(
     file_list = open(files, "r").readlines()
 
     module_collection = GrometFNModuleCollection(
-        schema_version="0.1.6",
+        schema_version=GROMET_VERSION,
         name=system_name,
         modules=[],
         module_index=[],

--- a/skema/program_analysis/script_functions.py
+++ b/skema/program_analysis/script_functions.py
@@ -5,7 +5,7 @@ import os.path
 import json
 
 # import astpp
-
+from skema.gromet import GROMET_VERSION
 from skema.gromet.fn import (
     GrometFNModuleCollection,
 )
@@ -50,7 +50,7 @@ def process_file_system(system_name, path, files, write_to_file=False):
     file_list = open(files, "r").readlines()
 
     module_collection = GrometFNModuleCollection(
-        schema_version="0.1.5",
+        schema_version=GROMET_VERSION,
         name=system_name,
         modules=[],
         module_index=[],

--- a/skema/skema_py/server.py
+++ b/skema/skema_py/server.py
@@ -42,7 +42,7 @@ def system_to_gromet(system: System):
         # Create files and intermediate directories
         for index, file in enumerate(system.files):
             file_path = Path(
-                tmp_path, system.root_name, file
+                tmp_path, system.root_name or "", file
             )
             file_path.parent.mkdir(parents=True, exist_ok=True)
             file_path.write_text(system.blobs[index])
@@ -55,8 +55,8 @@ def system_to_gromet(system: System):
 
         ## Run pipeline
         gromet_collection = process_file_system(
-            system.system_name,
-            str(Path(tmp_path, system.root_name)),
+            system.system_name or "",
+            str(Path(tmp_path, system.root_name or "")),
             str(system_filepaths),
         )
 


### PR DESCRIPTION
A couple of PA fields were marked as optional.  Setting these to `None` (as opposed to an empty string) led to errors.  This PR addresses cases where `None` is used.

I've also included a change related to #270 to consistently reference the current gromet version.