### PR TITLE
Add /fn-supported-file-extensions endpoint and additional skema-py endpoint updates

### DIFF
--- a/skema/program_analysis/comments.py
+++ b/skema/program_analysis/comments.py
@@ -1,0 +1,33 @@
+from typing import List, Dict, Optional, Union
+from pydantic import BaseModel, Field
+
+
+class SingleLineComment(BaseModel):
+    contents: str
+    line_number: int
+
+
+class SingleFileCodeComments(BaseModel):
+    docstrings: Dict[str, List[str]] = Field(
+        description="A dictionary mapping a function name (str) to its associated docstring (List[str])",
+        example={"fun1": ["Inputs: x,y", "Outputs: z"]},
+    )
+    comments: List[SingleLineComment] = Field(
+        description="A list of comments, where each comment has a 'line_number' (int) and 'contents' (str) field",
+        example=[{"contents": "Hello World!", "line_number": 0}],
+    )
+
+
+class MultiFileCodeComments(BaseModel):
+    files: Dict[str, SingleFileCodeComments] = Field(
+        description="Dictionary mapping file name (str) to extracted comments (SingleFileCodeComments)",
+        example={
+            "file1.py": {
+                "comments": [{"contents": "Hello World!", "line_number": 0}],
+                "docstrings": {"fun1": ["Inputs: x,y", "Outputs: z"]},
+            }
+        },
+    )
+
+
+CodeComments = Union[SingleFileCodeComments, MultiFileCodeComments]

--- a/skema/program_analysis/fn_unifier.py
+++ b/skema/program_analysis/fn_unifier.py
@@ -5,14 +5,18 @@
 # 3. Appending all comments from the comments JSON into the respective MetadataCollections for each FN
 
 from skema.program_analysis.JSON2GroMEt.json2gromet import json_to_gromet
+from skema.program_analysis.comments import (
+    CodeComments,
+    SingleFileCodeComments,
+    MultiFileCodeComments,
+)
 from skema.gromet.metadata.source_code_comment import SourceCodeComment
 from skema.gromet.metadata.source_code_reference import SourceCodeReference
 from skema.gromet.metadata.comment_type import CommentType
 from skema.gromet.fn.gromet_fn_module_collection import GrometFNModuleCollection
-
 from skema.utils.fold import dictionary_to_gromet_json, del_nulls
 
-from typing import Dict, Text, Any 
+from typing import Dict, Text, Any
 import argparse
 import json
 import re
@@ -21,44 +25,48 @@ import re
 def normalize_module_path(path: str):
     # The module paths in the GroMEt FN are dotted
     # We need slashes for the comments dictionary
-    return path.replace(".","/")
+    return path.replace(".", "/")
+
 
 def normalize_extraction_names(extraction: dict):
     # Removes extraneous characters and filename extensions
     # from the extraction dictionary
-    # Currently removes, ".py" extension 
+    # Currently removes, ".py" extension
     # and "./" from the keys
-    return { k.replace(".py","").replace("./", "") : v for k,v in extraction.items() }
+    return {k.replace(".py", "").replace("./", ""): v for k, v in extraction.items()}
+
 
 def strip_id(func_name):
     # Given a function name that ends with "_id###" where ### is a number
     # We remove that sequence of characters from the function name
     # The id is appended by the GroMEt generation, and so we can safely remove it
     # because we need the pure name of the function and not the identifier part
-    
+
     # Only strip the id if the func_name contains the pattern "_id###..." which
     # is appended by the Gromet generation
     if re.search("_id\d+", func_name):
         to_ret = list(func_name)
         to_ret.reverse()
         i = 0
-        while i < len(to_ret) and to_ret[i] != '_':
-            to_ret[i] = ''
+        while i < len(to_ret) and to_ret[i] != "_":
+            to_ret[i] = ""
             i += 1
-        to_ret[i] = ''
+        to_ret[i] = ""
         to_ret.reverse()
-        return ''.join(to_ret)
+        return "".join(to_ret)
     else:
         return func_name
 
+
 def find_source_code_reference(metadatum):
-    # Find a SourceCodeReference metadata in the metadatum entry 
+    # Find a SourceCodeReference metadata in the metadatum entry
     # we're looking at
     for elem in metadatum:
         if isinstance(elem, SourceCodeReference):
             return elem
-    
+
     return None
+
 
 def find_comment(comments, line_num):
     # Given the comments for a file and a line number, we find
@@ -69,11 +77,13 @@ def find_comment(comments, line_num):
 
     return None
 
+
 def insert_metadata(gromet_metadata, new_metadata):
     # Appends a new metadata to the end of the gromet_metadata
     # NOTE: not used now but will be in the future
     gromet_metadata.append([new_metadata])
     return len(gromet_metadata)
+
 
 def align_gromet_elements(gromet_metadata, gromet_comments, gromet_elements):
     # Gromet elements are generic enough that we can use
@@ -82,7 +92,7 @@ def align_gromet_elements(gromet_metadata, gromet_comments, gromet_elements):
     # TODO: associate code_file_reference_uid
     if gromet_elements != None:
         for elem in gromet_elements:
-            if elem.metadata != None: 
+            if elem.metadata != None:
                 metadatum = gromet_metadata[elem.metadata - 1]
                 source_ref = find_source_code_reference(metadatum)
                 if source_ref != None:
@@ -91,24 +101,25 @@ def align_gromet_elements(gromet_metadata, gromet_comments, gromet_elements):
                     comment = find_comment(gromet_comments, line_start)
                     if comment != None:
                         source_comment = SourceCodeComment(
-                            comment = comment,
-                            comment_type = CommentType.OTHER,
+                            comment=comment,
+                            comment_type=CommentType.OTHER,
                             context_function_name=None,
                             code_file_reference_uid=None,
                             line_begin=source_ref.line_begin,
                             line_end=source_ref.line_end,
                             col_begin=source_ref.col_begin,
-                            col_end=source_ref.col_end
+                            col_end=source_ref.col_end,
                         )
 
                         metadatum.append(source_comment)
 
                         # Find a comment metadata associated with that
 
+
 def align_fn(gromet_metadata, gromet_comments, gromet_fn):
     # Align the GroMEt b table
-    # We might be able to use the generic aligner but for now we align 
-    # independently 
+    # We might be able to use the generic aligner but for now we align
+    # independently
     if gromet_fn.b != None:
         for box in gromet_fn.b:
             if box.metadata != None:
@@ -120,18 +131,17 @@ def align_fn(gromet_metadata, gromet_comments, gromet_fn):
                     comment = find_comment(gromet_comments, line_start)
                     if comment != None:
                         source_comment = SourceCodeComment(
-                            comment = comment,
-                            comment_type = CommentType.OTHER,
+                            comment=comment,
+                            comment_type=CommentType.OTHER,
                             context_function_name=None,
                             code_file_reference_uid=None,
                             line_begin=source_ref.line_begin,
                             line_end=source_ref.line_end,
                             col_begin=source_ref.col_begin,
-                            col_end=source_ref.col_end
+                            col_end=source_ref.col_end,
                         )
 
                         metadatum.append(source_comment)
-
 
     # All these GroMEt elements all have metadata stored in the same way
     # So we can align any comments for all these using a generic aligner
@@ -154,18 +164,18 @@ def align_fn(gromet_metadata, gromet_comments, gromet_fn):
                 docstring = "".join(gromet_comments["docstrings"][normalized_func_name])
 
                 source_comment = SourceCodeComment(
-                    comment = docstring,
-                    comment_type = CommentType.DOCSTRING,
+                    comment=docstring,
+                    comment_type=CommentType.DOCSTRING,
                     context_function_name=normalized_func_name,
                     code_file_reference_uid=None,
                     line_begin=source_ref.line_begin,
                     line_end=source_ref.line_end,
                     col_begin=source_ref.col_begin,
-                    col_end=source_ref.col_end
+                    col_end=source_ref.col_end,
                 )
 
-                gromet_metadata[metadata_idx-1].append(source_comment)
-    
+                gromet_metadata[metadata_idx - 1].append(source_comment)
+
 
 def find_fn(gromet_modules, fn_name):
     # Given the gromet_modules list of FNs, we find fn_name in it
@@ -178,24 +188,31 @@ def find_fn(gromet_modules, fn_name):
     return None
 
 
-def align_full_system(gromet_obj, extraction):
+def align_full_system(gromet_obj: GrometFNModuleCollection, extraction: CodeComments):
     # Comments extraction file holds comments for all files in the system
 
     # The extracted comments json file can appear in two ways:
     #   - extractions for a single file:
-    #     A single file consists of one top level dictionary containing 
+    #     A single file consists of one top level dictionary containing
     #     the comments and docstrings for that file
     #   - extractions for a multi file
     #     A multi file consists of a top level dictionary that maps each file
     #     in the system to a dictionary containing the comments and docstrings for that file
     # We can check what kind of extracted comments file we have by checking the structure of the dictionary
-    if "comments" in extraction.keys() and "docstrings" in extraction.keys(): 
+    if isinstance(extraction, SingleFileCodeComments):
+        extraction = dict(extraction)
+    else:
+        extraction = dict(extraction.files)
+
+    if "comments" in extraction.keys() and "docstrings" in extraction.keys():
         # Single file system
         # NOTE: We assume for the moment that if we're aligning a single file that
         # The corresponding GroMEt has exactly one module
-        
+
         if len(gromet_obj.modules) != 1:
-            raise NotImplementedError("Single file alignment from a multi module GroMEt system not supported yet")
+            raise NotImplementedError(
+                "Single file alignment from a multi module GroMEt system not supported yet"
+            )
 
         module_FN = gromet_obj.modules[0]
         if module_FN != None:
@@ -216,16 +233,19 @@ def align_full_system(gromet_obj, extraction):
                 module_FN = find_fn(gromet_obj.modules, normalized_path)
                 if module_FN != None:
                     file_comments = extraction[normalized_path]
-                    
+
                     FN_metadata = module_FN.metadata_collection
                     align_fn(FN_metadata, file_comments, module_FN.fn)
 
                     if len(module_FN.fn_array) > 0:
                         for FN in module_FN.fn_array:
                             align_fn(FN_metadata, file_comments, FN)
-        
-def process_alignment(gromet_json: Dict[Text, Any], comments_json: Dict[Text, Any]) -> GrometFNModuleCollection:
-    # Given a GroMEt json and a comments json 
+
+
+def process_alignment(
+    gromet_json: Dict[Text, Any], comments_json: Dict[Text, Any]
+) -> GrometFNModuleCollection:
+    # Given a GroMEt json and a comments json
     # We run the alignment on the GroMEt to unify the comments with
     # The gromet JSON
     gromet_object = json_to_gromet(gromet_json)
@@ -233,19 +253,16 @@ def process_alignment(gromet_json: Dict[Text, Any], comments_json: Dict[Text, An
 
     return gromet_object
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--gromet", type=str, help="Path to a GroMEt JSON file"
-    )
-    parser.add_argument(
-        "--comments", type=str, help="Path to a Comments JSON file"
-    )
+    parser.add_argument("--gromet", type=str, help="Path to a GroMEt JSON file")
+    parser.add_argument("--comments", type=str, help="Path to a Comments JSON file")
     args = parser.parse_args()
 
     # Get the GroMEt JSON and turn it back into an object
     gromet_object = json_to_gromet(args.gromet)
-    
+
     # Get the comments data from the JSON file
     comments_file = open(args.comments, "r")
     comments_json = json.load(comments_file)
@@ -256,7 +273,4 @@ if __name__ == "__main__":
     # Write out the gromet with the comments
     with open(args.gromet, "w") as f:
         gromet_collection_dict = gromet_object.to_dict()
-        f.write(
-            dictionary_to_gromet_json(del_nulls(gromet_collection_dict))
-        )
-
+        f.write(dictionary_to_gromet_json(del_nulls(gromet_collection_dict)))

--- a/skema/skema_py/server.py
+++ b/skema/skema_py/server.py
@@ -18,15 +18,32 @@ from skema.utils.fold import dictionary_to_gromet_json, del_nulls
 
 FN_SUPPORTED_FILE_EXTENSIONS = [".py", ".f95", ".f"]
 
+
 class Ports(BaseModel):
     opis: List[str]
     opos: List[str]
 
+
 class System(BaseModel):
-    files: List[str] = Field(description="The relative file path from the directory specified by `root_name`, corresponding to each entry in `blobs`", example=["example1.py", "dir/example2.py"])
-    blobs: List[str] = Field(decription="Contents of each file to be analyzed", example=["greet = lambda: print('howdy!')\ngreet()"])
-    system_name: Optional[str] = Field(default=None, decription="A model name to associate with the provided code", example="my-system")
-    root_name: Optional[str] = Field(default=None, decription="The name of the code system's root directory.", example="my-system")
+    files: List[str] = Field(
+        description="The relative file path from the directory specified by `root_name`, corresponding to each entry in `blobs`",
+        example=["example1.py", "dir/example2.py"],
+    )
+    blobs: List[str] = Field(
+        decription="Contents of each file to be analyzed",
+        example=["greet = lambda: print('howdy!')\ngreet()"],
+    )
+    system_name: Optional[str] = Field(
+        default=None,
+        decription="A model name to associate with the provided code",
+        example="my-system",
+    )
+    root_name: Optional[str] = Field(
+        default=None,
+        decription="The name of the code system's root directory.",
+        example="my-system",
+    )
+
 
 def system_to_gromet(system: System):
     """Convert a System to Gromet JSON"""
@@ -39,16 +56,12 @@ def system_to_gromet(system: System):
 
         # Create files and intermediate directories
         for index, file in enumerate(system.files):
-            file_path = Path(
-                tmp_path, system.root_name or "", file
-            )
+            file_path = Path(tmp_path, system.root_name or "", file)
             file_path.parent.mkdir(parents=True, exist_ok=True)
             file_path.write_text(system.blobs[index])
 
         # Create system_filepaths.txt
-        system_filepaths = Path(
-            tmp_path, "system_filepaths.txt"
-        )
+        system_filepaths = Path(tmp_path, "system_filepaths.txt")
         system_filepaths.write_text("\n".join(system.files))
 
         ## Run pipeline
@@ -64,11 +77,16 @@ def system_to_gromet(system: System):
 
 app = FastAPI()
 
+
 @app.get("/ping", summary="Ping endpoint to test health of service")
 def ping():
     return "The skema-py service is running."
 
-@app.get("/fn-supported-file-extensions", summary="Endpoint for checking which files extensions are currently supported by code2fn pipeline.")
+
+@app.get(
+    "/fn-supported-file-extensions",
+    summary="Endpoint for checking which files extensions are currently supported by code2fn pipeline.",
+)
 def fn_supported_file_extensions():
     """
     Returns a List[str] where each entry in the list represents a file extension.
@@ -79,9 +97,10 @@ def fn_supported_file_extensions():
 
     response = requests.get("http://0.0.0.0:8000/fn-supported-file-extensions")
     supported_extensions = response.json()
-    
+
     """
     return FN_SUPPORTED_FILE_EXTENSIONS
+
 
 @app.post(
     "/fn-given-filepaths",
@@ -92,12 +111,12 @@ def fn_supported_file_extensions():
 )
 async def fn_given_filepaths(system: System):
     """
-    Endpoint for generating Gromet JSON from a serialized code system. 
+    Endpoint for generating Gromet JSON from a serialized code system.
     ### Python example
-    
+
     ```
     import requests
-    
+
     # Single file
     system = {
       "files": ["exp1.py"],
@@ -110,7 +129,7 @@ async def fn_given_filepaths(system: System):
     system = {
       "files": ["exp1.py", "exp1.f"],
       "blobs": ["x=2", "program exp1\\ninteger::x=2\\nend program exp1"],
-      "system_name": "exp1", 
+      "system_name": "exp1",
       "root_name": "exp1"
     }
     response = requests.post("http://0.0.0.0:8000/fn-given-filepaths", json=system)
@@ -143,7 +162,7 @@ async def fn_given_filepaths_zip(zip_file: UploadFile = File()):
     output_name = "system_test.zip"
     input_path = Path("/data") / "skema" / "code" / input_name
     output_path = Path("/data") / "skema" / "code" / output_name
-    
+
     # Convert source directory to zip archive
     shutil.make_archive(input_path, "zip", input_path)
 

--- a/skema/skema_py/server.py
+++ b/skema/skema_py/server.py
@@ -16,20 +16,18 @@ from skema.program_analysis.multi_file_ingester import process_file_system
 from skema.program_analysis.snippet_ingester import process_snippet
 from skema.utils.fold import dictionary_to_gromet_json, del_nulls
 
+FN_SUPPORTED_FILE_EXTENSIONS = [".py", ".f95", ".f"]
 
 class Ports(BaseModel):
     opis: List[str]
     opos: List[str]
 
-
 class System(BaseModel):
-    files: List[str] = Field(description="The file name corresponding to each entry in `blobs`", example=["example.py"])
+    files: List[str] = Field(description="The relative file path from the directory specified by `root_name`, corresponding to each entry in `blobs`", example=["example1.py", "dir/example2.py"])
     blobs: List[str] = Field(decription="Contents of each file to be analyzed", example=["greet = lambda: print('howdy!')\ngreet()"])
     system_name: Optional[str] = Field(default=None, decription="A model name to associate with the provided code", example="my-system")
-    root_name: Optional[str] = Field(default=None, decription="????", example=None)
+    root_name: Optional[str] = Field(default=None, decription="The name of the code system's root directory.", example="my-system")
 
-
-# FIXME: why does this return a a string?
 def system_to_gromet(system: System):
     """Convert a System to Gromet JSON"""
 
@@ -60,18 +58,30 @@ def system_to_gromet(system: System):
             str(system_filepaths),
         )
 
-    # Convert gromet data-model to json
-    gromet_collection_dict = gromet_collection.to_dict()
-    return dictionary_to_gromet_json(del_nulls(gromet_collection_dict))
+    # Convert Gromet data-model to dict for return
+    return gromet_collection.to_dict()
 
 
 app = FastAPI()
-
 
 @app.get("/ping", summary="Ping endpoint to test health of service")
 def ping():
     return "The skema-py service is running."
 
+@app.get("/fn-supported-file-extensions", summary="Endpoint for checking which files extensions are currently supported by code2fn pipeline.")
+def fn_supported_file_extensions():
+    """
+    Returns a List[str] where each entry in the list represents a file extension.
+
+    ### Python example
+    ```
+    import requests
+
+    response = requests.get("http://0.0.0.0:8000/fn-supported-file-extensions")
+    supported_extensions = response.json()
+    
+    """
+    return FN_SUPPORTED_FILE_EXTENSIONS
 
 @app.post(
     "/fn-given-filepaths",
@@ -82,21 +92,32 @@ def ping():
 )
 async def fn_given_filepaths(system: System):
     """
-    Endpoint for generating Gromet JSON from a .
-
+    Endpoint for generating Gromet JSON from a serialized code system. 
     ### Python example
+    
     ```
     import requests
-
+    
+    # Single file
     system = {
       "files": ["exp1.py"],
       "blobs": ["x=2"]
     }
     response = requests.post("http://0.0.0.0:8000/fn-given-filepaths", json=system)
     gromet_json = response.json()
+
+    # Multi file
+    system = {
+      "files": ["exp1.py", "exp1.f"],
+      "blobs": ["x=2", "program exp1\\ninteger::x=2\\nend program exp1"],
+      "system_name": "exp1", 
+      "root_name": "exp1"
+    }
+    response = requests.post("http://0.0.0.0:8000/fn-given-filepaths", json=system)
+    gromet_json = response.json()
     """
-    # FIXME: remove json.loads() wrapper after use of dictionary_to_gromet_json is addressed
-    return json.loads(system_to_gromet(system))
+
+    return system_to_gromet(system)
 
 
 @app.post(
@@ -106,16 +127,28 @@ async def fn_given_filepaths(system: System):
         " get a GroMEt FN Module collection back."
     ),
 )
-async def root(zip_file: UploadFile = File()):
+async def fn_given_filepaths_zip(zip_file: UploadFile = File()):
     """
-    Endpoint for generating Gromet JSON from a zip archive.
+    Endpoint for generating Gromet JSON from a zip archive of arbitrary depth and structure.
+    All source files with a supported file extension (/fn-supported-file-extensions) will be processed as a single GrometFNModuleCollection.
 
     ### Python example
     ```
     import requests
+    import shutil
+    from pathlib import Path
+
+    # Format input/output paths
+    input_name = "system_test"
+    output_name = "system_test.zip"
+    input_path = Path("/data") / "skema" / "code" / input_name
+    output_path = Path("/data") / "skema" / "code" / output_name
+    
+    # Convert source directory to zip archive
+    shutil.make_archive(input_path, "zip", input_path)
 
     files = {
-      "zip_file": open("code_system.zip", "rb"),
+      "zip_file": open(output_path, "rb"),
     }
     response = requests.post("http://0.0.0.0:8000/fn-given-filepaths-zip", files=files)
     gromet_json = response.json()
@@ -141,8 +174,8 @@ async def root(zip_file: UploadFile = File()):
     system = System(
         files=files, blobs=blobs, system_name=system_name, root_name=root_name
     )
-    # FIXME: remove json.loads() wrapper after use of dictionary_to_gromet_json is addressed
-    return json.loads(system_to_gromet(system))
+
+    return system_to_gromet(system)
 
 
 @app.post(

--- a/skema/skema_py/server.py
+++ b/skema/skema_py/server.py
@@ -173,16 +173,13 @@ async def fn_given_filepaths_zip(zip_file: UploadFile = File()):
     gromet_json = response.json()
     """
 
-    # Currently, we rely on the file extension to know which language front end to send the source code to.
-    supported_file_extensions = [".py", ".f", ".f95"]
-
     # To process a zip file, we first convert it to a System object, and then pass it to system_to_gromet.
     files = []
     blobs = []
     with ZipFile(BytesIO(zip_file.file.read()), "r") as zip:
         for file in zip.namelist():
             file_obj = Path(file)
-            if file_obj.suffix in supported_file_extensions:
+            if file_obj.suffix in FN_SUPPORTED_FILE_EXTENSIONS:
                 files.append(file)
                 blobs.append(zip.open(file).read())
 


### PR DESCRIPTION
- Adds /fn-supported-file-extensions endpoint which returns the file extensions that are currently supported by the code2fn pipeline
- system_to_gromet() now returns a Dict instead of a raw JSON string. The placeholder json.load() calls have been removed from fn_given_filepaths and fn_given_filepaths_zip
- Updates description of System fields
- Updates endpoint descriptions and examples 
