### PR TITLE
Resolves issue related to use of Literal

### DIFF
--- a/Dockerfile.skema-py
+++ b/Dockerfile.skema-py
@@ -38,7 +38,6 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Install the skema package
 RUN pip install wheel
-RUN pip install fastapi uvicorn
 RUN pip install six
 # Download ML model (~150MB)
 # FIXME: consider publishing and retrieving this model from HF Hub

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies=[
     "PyYAML",
     "tree-sitter",
     "requests",
+    "typing_extensions==4.5.0", # see https://github.com/pydantic/pydantic/issues/5821#issuecomment-1559196859
     "fastapi",
     "uvicorn",
     "python-multipart"

--- a/skema/rest/schema.py
+++ b/skema/rest/schema.py
@@ -4,7 +4,9 @@ Response models for API
 """
 
 from pydantic import BaseModel, Field
-from typing import List, Literal
+from typing import List
+# see https://github.com/pydantic/pydantic/issues/5821#issuecomment-1559196859
+from typing_extensions import Literal
 from skema.img2mml import eqn2mml
 
 


### PR DESCRIPTION
Quick fix to address an error encountered when launching the REST API (related to use of `Literal` with pydantic/fastapi).  Relates to https://github.com/pydantic/pydantic/issues/5821#issuecomment-1559196859

