### PR TITLE
Adding smokescreen test for /mathml/amr PUT endpoint

### DIFF
--- a/skema/skema-rs/skema/src/services/mathml.rs
+++ b/skema/skema-rs/skema/src/services/mathml.rs
@@ -1,4 +1,4 @@
-use actix_web::{put, web, HttpResponse};
+use actix_web::{put, web, HttpResponse, test};
 use mathml::{
     acset::{ACSet, AMRmathml, PetriNet, RegNet},
     ast::Math,
@@ -87,7 +87,8 @@ pub async fn get_regnet(payload: web::Json<Vec<String>>) -> HttpResponse {
     HttpResponse::Ok().json(web::Json(RegNet::from(asts)))
 }
 
-/// Return a JSON representation of an AMR constructed from an array of MathML strings and a string for the AMR subtype
+/// Return a JSON representation of an AMR constructed from an array of MathML strings and a string
+/// for the AMR subtype.
 #[utoipa::path(
     request_body = AMRmathml,
     responses(

--- a/skema/skema-rs/skema/tests/data/get_amr_payload.json
+++ b/skema/skema-rs/skema/tests/data/get_amr_payload.json
@@ -1,0 +1,7 @@
+{
+    "mathml": [
+      "<math alttext=\"\\frac{\\delta x}{\\delta t} = {\\alpha x} - {\\beta x y}\" display=\"block\" xmlns=\"http://www.w3.org/1998/Math/MathML\"><mfrac><mrow><mi>d</mi><mi>x</mi></mrow><mrow><mi>d</mi><mi>t</mi></mrow></mfrac><mo>=</mo><mi>α</mi><mi>x</mi><mo>−</mo><mi>β</mi><mi>x</mi><mi>y</mi></math>",
+      "<math alttext=\"\\frac{\\delta y}{\\delta t} = {\\alpha x y} - {\\gamma y}\" display=\"block\" xmlns=\"http://www.w3.org/1998/Math/MathML\"><mfrac><mrow><mi>d</mi><mi>y</mi></mrow><mrow><mi>d</mi><mi>t</mi></mrow></mfrac><mo>=</mo><mi>α</mi><mi>x</mi><mi>y</mi><mo>−</mo><mi>γ</mi><mi>y</mi></math>"
+    ],
+    "model": "regnet"
+  }

--- a/skema/skema-rs/skema/tests/test_service.rs
+++ b/skema/skema-rs/skema/tests/test_service.rs
@@ -1,17 +1,34 @@
-use actix_web::{test, App};
-use skema::services::comment_extraction::{get_comments, CommentExtractionRequest, Language};
+use actix_web::{test, App, http::{self, header::ContentType}};
+use skema::services::{
+    comment_extraction::{get_comments, CommentExtractionRequest, Language},
+    mathml::get_amr
+};
+use std::fs;
 
 #[actix_web::test]
 async fn test_get_comments() {
     let app = test::init_service(App::new().service(get_comments)).await;
     let payload = CommentExtractionRequest::new(
         Language::Python,
-        std::fs::read_to_string("../comment_extraction/tests/data/CHIME_SIR.py").unwrap(),
+        fs::read_to_string("../comment_extraction/tests/data/CHIME_SIR.py").unwrap(),
     );
     let request = test::TestRequest::post()
         .uri("/extract-comments")
         .set_json(&payload)
         .to_request();
     let response = test::call_service(&app, request).await;
+    assert!(response.status().is_success());
+}
+
+#[actix_web::test]
+async fn test_get_amr() {
+    let app = test::init_service(App::new().service(get_amr)).await;
+    let payload = fs::read_to_string("tests/data/get_amr_payload.json").unwrap();
+    let request = test::TestRequest::put()
+        .uri("/mathml/amr")
+        .insert_header(ContentType::json())
+        .set_payload(payload).to_request();
+    let response = test::call_service(&app, request).await;
+    println!("{:?}", response);
     assert!(response.status().is_success());
 }

--- a/skema/skema-rs/skema/tests/test_service.rs
+++ b/skema/skema-rs/skema/tests/test_service.rs
@@ -29,6 +29,5 @@ async fn test_get_amr() {
         .insert_header(ContentType::json())
         .set_payload(payload).to_request();
     let response = test::call_service(&app, request).await;
-    println!("{:?}", response);
     assert!(response.status().is_success());
 }


### PR DESCRIPTION
This PR adds a smokescreen unit test for the `/mathml/amr` PUT endpoint in the skema-rs REST API.