### PR TITLE
[skema-py] - Automatically enrich System with comments

### DIFF
--- a/skema/rest/workflows.py
+++ b/skema/rest/workflows.py
@@ -91,8 +91,6 @@ async def equations_to_amr(data: schema.EquationLatexToAMR):
 # code snippets -> fn -> petrinet amr
 @router.post("/code/snippets-to-pn-amr", summary="Code snippets → PetriNet AMR")
 async def code_snippets_to_pn_amr(system: code2fn.System):
-    if system.comments == None:
-        system = await code2fn.system_to_enriched_system(system)
     gromet = await code2fn.fn_given_filepaths(system)
     res = requests.post(f"{SKEMA_RS_ADDESS}/models/PN", json=gromet)
     if res.status_code != 200:
@@ -103,8 +101,6 @@ async def code_snippets_to_pn_amr(system: code2fn.System):
 # code snippets -> fn -> regnet amr
 @router.post("/code/snippets-to-rn-amr", summary="Code snippets → RegNet AMR")
 async def code_snippets_to_rn_amr(system: code2fn.System):
-    if system.comments == None:
-        system = await code2fn.system_to_enriched_system(system)
     gromet = await code2fn.fn_given_filepaths(system)
     res = requests.post(f"{SKEMA_RS_ADDESS}/models/RN", json=gromet)
     if res.status_code != 200:

--- a/skema/rest/workflows.py
+++ b/skema/rest/workflows.py
@@ -89,9 +89,6 @@ async def equations_to_amr(data: schema.EquationLatexToAMR):
 # code snippets -> fn -> petrinet amr
 @router.post("/code/snippets-to-pn-amr", summary="Code snippets → PetriNet AMR")
 async def code_snippets_to_pn_amr(system: code2fn.System):
-    if system.comments == None:
-        # FIXME: get comments
-        pass
     gromet = await code2fn.fn_given_filepaths(system)
     res = requests.post(f"{SKEMA_RS_ADDESS}/models/PN", json=gromet)
     if res.status_code != 200:
@@ -103,9 +100,6 @@ async def code_snippets_to_pn_amr(system: code2fn.System):
 # code snippets -> fn -> regnet amr
 @router.post("/code/snippets-to-rn-amr", summary="Code snippets → RegNet AMR")
 async def code_snippets_to_rn_amr(system: code2fn.System):
-    if system.comments == None:
-        # FIXME: get comments and produce another system
-        pass
     gromet = await code2fn.fn_given_filepaths(system)
     res = requests.post(f"{SKEMA_RS_ADDESS}/models/RN", json=gromet)
     if res.status_code != 200:
@@ -128,7 +122,6 @@ async def repo_to_pn_amr(zip_file: UploadFile = File()):
 # zip archive -> fn -> regnet amr
 @router.post("/code/codebase-to-rn-amr", summary="Code repo (zip archive) → RegNet AMR")
 async def repo_to_rn_amr(zip_file: UploadFile = File()):
-    # FIXME: get comments
     gromet = await code2fn.fn_given_filepaths_zip(zip_file)
     res = requests.post(f"{SKEMA_RS_ADDESS}/models/RN", json=gromet)
     if res.status_code != 200:

--- a/skema/rest/workflows.py
+++ b/skema/rest/workflows.py
@@ -13,7 +13,6 @@ from skema.skema_py import server as code2fn
 from fastapi import APIRouter, File, UploadFile
 from starlette.responses import JSONResponse
 import requests
-import json
 
 
 router = APIRouter()

--- a/skema/skema_py/server.py
+++ b/skema/skema_py/server.py
@@ -269,8 +269,8 @@ async def fn_given_filepaths_zip(zip_file: UploadFile = File()):
                 blobs.append(zip.open(file).read())
 
     zip_obj = Path(zip_file.filename)
-    system_name = zip_obj.name
-    root_name = zip_obj.name
+    system_name = zip_obj.stem
+    root_name = zip_obj.stem
 
     system = System(
         files=files, blobs=blobs, system_name=system_name, root_name=root_name

--- a/skema/skema_py/server.py
+++ b/skema/skema_py/server.py
@@ -80,7 +80,6 @@ def system_to_enriched_system(system: System) -> System:
 
     # Check if Rust is installed on the system. If not, then return the system as is.
     if not which("cargo"):
-        print("HERE")
         return system
 
     # Create a temporary directory to store the input source files.

--- a/skema/skema_py/server.py
+++ b/skema/skema_py/server.py
@@ -79,7 +79,8 @@ def system_to_enriched_system(system: System) -> System:
     skema_rs_path = Path(__file__).parent.parent / "skema-rs" / "comment_extraction"
 
     # Check if Rust is installed on the system. If not, then return the system as is.
-    if which("cargo") is None:
+    if not which("cargo"):
+        print("HERE")
         return system
 
     # Create a temporary directory to store the input source files.

--- a/skema/skema_py/server.py
+++ b/skema/skema_py/server.py
@@ -1,15 +1,12 @@
 import json
 import os
 import tempfile
-import subprocess
-import requests
-from shutil import which
 from pathlib import Path
 from typing import List, Dict, Optional
 from io import BytesIO
 from zipfile import ZipFile
 from urllib.request import urlopen
-from fastapi import APIRouter, FastAPI, Body, File, Form, UploadFile
+from fastapi import APIRouter, FastAPI, Body, File, UploadFile
 from pydantic import BaseModel, Field
 
 import skema.skema_py.acsets


### PR DESCRIPTION
Adds `system_to_enriched_system` function which takes a System as input and attempts to return an enriched system with comments added. This is done by running the calling the Rust comment extractor proxy endpoint over the files in System.blobs.
**Notes:**
-  Due to a quirk of the fn-unifier, System.root_name must be set for automatic comment enrichment to work. Gromet will still be returned from the endpoint, but the comments will not be included. This only affects the fn-given-filepaths endpoint. fn-given-filepaths-zip will automatically determine the root_name.

Adds a call to `system_to_enriched_system` in `system_to_gromet`. Now any endpoint using this function (fn-given-filepaths, fn-given-filepaths-zip) will automatically attempt to extract and unify comments. 

Removes comment enrichment stubs from skema/rest/workflows.py. This logic will be handled directly from the endpoints.

Resolves #310 #311 
