### PR TITLE
Support for parsing MathML with light interpretation

### DIFF
--- a/skema/skema-rs/mathml/src/parsers.rs
+++ b/skema/skema-rs/mathml/src/parsers.rs
@@ -1,3 +1,4 @@
 pub mod first_order_ode;
 pub mod generic_mathml;
+pub mod interpreted_mathml;
 pub mod math_expression_tree;

--- a/skema/skema-rs/mathml/src/parsers/first_order_ode.rs
+++ b/skema/skema-rs/mathml/src/parsers/first_order_ode.rs
@@ -1,27 +1,31 @@
 use crate::{
     ast::{
         operator::{Derivative, Operator},
-        Ci, MathExpression, Mi, Mrow, Type,
+        Ci, MathExpression, Type,
     },
-    parsers::generic_mathml::{
-        add, attribute, equals, etag, lparen, mi, mn, msqrt, msub, msubsup, msup, rparen, stag,
-        subtract, tag_parser, ws, IResult, ParseError, Span,
+    parsers::{
+        generic_mathml::{attribute, equals, etag, stag, ws, IResult, Span},
+        interpreted_mathml::{
+            ci_univariate_func, ci_unknown, first_order_derivative_leibniz_notation,
+            math_expression, newtonian_derivative, operator,
+        },
+        math_expression_tree::MathExpressionTree,
     },
-    parsers::math_expression_tree::MathExpressionTree,
 };
+
 use derive_new::new;
 use nom::{
     branch::alt,
     bytes::complete::tag,
-    combinator::{map, opt},
+    combinator::map,
     error::Error,
     multi::{many0, many1},
-    sequence::{delimited, pair, terminated, tuple},
+    sequence::{delimited, tuple},
 };
 use std::str::FromStr;
 
 #[cfg(test)]
-use crate::parsers::generic_mathml::test_parser;
+use crate::{ast::Mi, parsers::generic_mathml::test_parser};
 
 /// First order ordinary differential equation.
 /// This assumes that the left hand side of the equation consists solely of a derivative expressed
@@ -35,164 +39,6 @@ pub struct FirstOrderODE {
 
     /// An expression tree corresponding to the RHS of the ODE.
     pub rhs: MathExpressionTree,
-}
-
-impl FirstOrderODE {
-    pub fn to_cmml(&self) -> String {
-        let lhs_expression_tree = MathExpressionTree::Cons(
-            Operator::Derivative(Derivative::new(1, 1)),
-            vec![MathExpressionTree::Atom(MathExpression::Ci(
-                self.lhs_var.clone(),
-            ))],
-        );
-        let combined = MathExpressionTree::Cons(
-            Operator::Equals,
-            vec![lhs_expression_tree, self.rhs.clone()],
-        );
-        combined.to_cmml()
-    }
-}
-
-/// Function to parse operators. This function differs from the one in parsers::generic_mathml by
-/// disallowing operators besides +, -, =, (, and ).
-pub fn operator(input: Span) -> IResult<Operator> {
-    let (s, op) = ws(delimited(
-        stag!("mo"),
-        alt((add, subtract, equals, lparen, rparen)),
-        etag!("mo"),
-    ))(input)?;
-    Ok((s, op))
-}
-
-fn parenthesized_identifier(input: Span) -> IResult<()> {
-    let mo_lparen = delimited(stag!("mo"), lparen, etag!("mo"));
-    let mo_rparen = delimited(stag!("mo"), rparen, etag!("mo"));
-    let (s, _) = delimited(mo_lparen, mi, mo_rparen)(input)?;
-    Ok((s, ()))
-}
-
-/// Parse content identifiers corresponding to univariate functions.
-/// Example: S(t)
-fn ci_univariate_func(input: Span) -> IResult<Ci> {
-    let (s, (Mi(x), _pi)) = tuple((mi, parenthesized_identifier))(input)?;
-    Ok((
-        s,
-        Ci::new(
-            Some(Type::Function),
-            Box::new(MathExpression::Mi(Mi(x.trim().to_string()))),
-        ),
-    ))
-}
-
-/// Parse the identifier 'd'
-fn d(input: Span) -> IResult<()> {
-    let (s, Mi(x)) = mi(input)?;
-    if let "d" = x.as_ref() {
-        Ok((s, ()))
-    } else {
-        Err(nom::Err::Error(ParseError::new(
-            "Unable to identify Mi('d')".to_string(),
-            input,
-        )))
-    }
-}
-
-/// Parse a content identifier of unknown type.
-fn ci_unknown(input: Span) -> IResult<Ci> {
-    let (s, x) = mi(input)?;
-    Ok((s, Ci::new(None, Box::new(MathExpression::Mi(x)))))
-}
-
-/// Parse a first-order ordinary derivative written in Leibniz notation.
-fn first_order_derivative_leibniz_notation(input: Span) -> IResult<(Derivative, Ci)> {
-    let (s, _) = tuple((stag!("mfrac"), stag!("mrow"), d))(input)?;
-    let (s, func) = ws(alt((
-        ci_univariate_func,
-        map(ci_unknown, |Ci { content, .. }| Ci {
-            r#type: Some(Type::Function),
-            content,
-        }),
-    )))(s)?;
-    let (s, _) = tuple((
-        etag!("mrow"),
-        stag!("mrow"),
-        d,
-        mi,
-        etag!("mrow"),
-        etag!("mfrac"),
-    ))(s)?;
-    Ok((s, (Derivative::new(1, 1), func)))
-}
-
-fn newtonian_derivative(input: Span) -> IResult<(Derivative, Ci)> {
-    // Get number of dots to recognize the order of the derivative
-    let n_dots = delimited(
-        stag!("mo"),
-        map(many1(nom::character::complete::char('˙')), |x| {
-            x.len() as u8
-        }),
-        etag!("mo"),
-    );
-
-    let (s, (x, order)) = terminated(
-        delimited(
-            stag!("mover"),
-            pair(
-                map(ci_unknown, |Ci { content, .. }| Ci {
-                    r#type: Some(Type::Function),
-                    content,
-                }),
-                n_dots,
-            ),
-            etag!("mover"),
-        ),
-        opt(parenthesized_identifier),
-    )(input)?;
-
-    Ok((s, (Derivative::new(order, 1), x)))
-}
-
-// We reimplement the mfrac and mrow parsers in this file (instead of importing them from
-// the generic_mathml module) to work with the specialized version of the math_expression parser
-// (also in this file).
-pub fn mfrac(input: Span) -> IResult<MathExpression> {
-    let (s, frac) = ws(map(
-        tag_parser!("mfrac", pair(math_expression, math_expression)),
-        |(x, y)| MathExpression::Mfrac(Box::new(x), Box::new(y)),
-    ))(input)?;
-
-    Ok((s, frac))
-}
-
-pub fn mrow(input: Span) -> IResult<Mrow> {
-    let (s, elements) = ws(delimited(
-        stag!("mrow"),
-        many0(math_expression),
-        etag!("mrow"),
-    ))(input)?;
-    Ok((s, Mrow(elements)))
-}
-
-/// Parser for math expressions. This varies from the one in the generic_mathml module, since it
-/// assumes that expressions such as S(t) are actually univariate functions.
-pub fn math_expression(input: Span) -> IResult<MathExpression> {
-    ws(alt((
-        map(ci_univariate_func, MathExpression::Ci),
-        map(ci_unknown, |Ci { content, .. }| {
-            MathExpression::Ci(Ci {
-                r#type: Some(Type::Function),
-                content,
-            })
-        }),
-        map(operator, MathExpression::Mo),
-        mn,
-        msup,
-        msub,
-        msqrt,
-        mfrac,
-        map(mrow, MathExpression::Mrow),
-        msubsup,
-    )))(input)
 }
 
 /// Parse a first order ODE with a single derivative term on the LHS.
@@ -229,6 +75,22 @@ pub fn first_order_ode(input: Span) -> IResult<FirstOrderODE> {
     };
 
     Ok((s, ode))
+}
+
+impl FirstOrderODE {
+    pub fn to_cmml(&self) -> String {
+        let lhs_expression_tree = MathExpressionTree::Cons(
+            Operator::Derivative(Derivative::new(1, 1)),
+            vec![MathExpressionTree::Atom(MathExpression::Ci(
+                self.lhs_var.clone(),
+            ))],
+        );
+        let combined = MathExpressionTree::Cons(
+            Operator::Equals,
+            vec![lhs_expression_tree, self.rhs.clone()],
+        );
+        combined.to_cmml()
+    }
 }
 
 impl FromStr for FirstOrderODE {

--- a/skema/skema-rs/mathml/src/parsers/interpreted_mathml.rs
+++ b/skema/skema-rs/mathml/src/parsers/interpreted_mathml.rs
@@ -1,0 +1,173 @@
+//! This module contains parsers that perform some amount of preliminary domain-specific
+//! interpretation of presentation MathML (e.g., globbing S(t) to an identifier S of type
+//! 'function'). This is in contrast to the `generic_mathml.rs` module that contains parsers that
+//! do not attempt to perform any interpretation but instead simply preserve the original MathML
+//! document structure.
+
+use crate::{
+    ast::{
+        operator::{Derivative, Operator},
+        Ci, Math, MathExpression, Mi, Mrow, Type,
+    },
+    parsers::generic_mathml::{
+        add, attribute, elem_many0, equals, etag, lparen, mi, mn, msqrt, msub, msubsup, msup,
+        rparen, stag, subtract, tag_parser, ws, xml_declaration, IResult, ParseError, Span,
+    },
+};
+
+use nom::{
+    branch::alt,
+    bytes::complete::tag,
+    combinator::{map, opt},
+    multi::{many0, many1},
+    sequence::{delimited, pair, preceded, terminated, tuple},
+};
+
+/// Function to parse operators. This function differs from the one in parsers::generic_mathml by
+/// disallowing operators besides +, -, =, (, and ).
+pub fn operator(input: Span) -> IResult<Operator> {
+    let (s, op) = ws(delimited(
+        stag!("mo"),
+        alt((add, subtract, equals, lparen, rparen)),
+        etag!("mo"),
+    ))(input)?;
+    Ok((s, op))
+}
+
+fn parenthesized_identifier(input: Span) -> IResult<()> {
+    let mo_lparen = delimited(stag!("mo"), lparen, etag!("mo"));
+    let mo_rparen = delimited(stag!("mo"), rparen, etag!("mo"));
+    let (s, _) = delimited(mo_lparen, mi, mo_rparen)(input)?;
+    Ok((s, ()))
+}
+
+/// Parse content identifiers corresponding to univariate functions.
+/// Example: S(t)
+pub fn ci_univariate_func(input: Span) -> IResult<Ci> {
+    let (s, (Mi(x), _pi)) = tuple((mi, parenthesized_identifier))(input)?;
+    Ok((
+        s,
+        Ci::new(
+            Some(Type::Function),
+            Box::new(MathExpression::Mi(Mi(x.trim().to_string()))),
+        ),
+    ))
+}
+
+/// Parse the identifier 'd'
+fn d(input: Span) -> IResult<()> {
+    let (s, Mi(x)) = mi(input)?;
+    if let "d" = x.as_ref() {
+        Ok((s, ()))
+    } else {
+        Err(nom::Err::Error(ParseError::new(
+            "Unable to identify Mi('d')".to_string(),
+            input,
+        )))
+    }
+}
+
+/// Parse a content identifier of unknown type.
+pub fn ci_unknown(input: Span) -> IResult<Ci> {
+    let (s, x) = mi(input)?;
+    Ok((s, Ci::new(None, Box::new(MathExpression::Mi(x)))))
+}
+
+/// Parse a first-order ordinary derivative written in Leibniz notation.
+pub fn first_order_derivative_leibniz_notation(input: Span) -> IResult<(Derivative, Ci)> {
+    let (s, _) = tuple((stag!("mfrac"), stag!("mrow"), d))(input)?;
+    let (s, func) = ws(alt((
+        ci_univariate_func,
+        map(ci_unknown, |Ci { content, .. }| Ci {
+            r#type: Some(Type::Function),
+            content,
+        }),
+    )))(s)?;
+    let (s, _) = tuple((
+        etag!("mrow"),
+        stag!("mrow"),
+        d,
+        mi,
+        etag!("mrow"),
+        etag!("mfrac"),
+    ))(s)?;
+    Ok((s, (Derivative::new(1, 1), func)))
+}
+
+pub fn newtonian_derivative(input: Span) -> IResult<(Derivative, Ci)> {
+    // Get number of dots to recognize the order of the derivative
+    let n_dots = delimited(
+        stag!("mo"),
+        map(many1(nom::character::complete::char('˙')), |x| {
+            x.len() as u8
+        }),
+        etag!("mo"),
+    );
+
+    let (s, (x, order)) = terminated(
+        delimited(
+            stag!("mover"),
+            pair(
+                map(ci_unknown, |Ci { content, .. }| Ci {
+                    r#type: Some(Type::Function),
+                    content,
+                }),
+                n_dots,
+            ),
+            etag!("mover"),
+        ),
+        opt(parenthesized_identifier),
+    )(input)?;
+
+    Ok((s, (Derivative::new(order, 1), x)))
+}
+
+// We reimplement the mfrac and mrow parsers in this file (instead of importing them from
+// the generic_mathml module) to work with the specialized version of the math_expression parser
+// (also in this file).
+pub fn mfrac(input: Span) -> IResult<MathExpression> {
+    let (s, frac) = ws(map(
+        tag_parser!("mfrac", pair(math_expression, math_expression)),
+        |(x, y)| MathExpression::Mfrac(Box::new(x), Box::new(y)),
+    ))(input)?;
+
+    Ok((s, frac))
+}
+
+pub fn mrow(input: Span) -> IResult<Mrow> {
+    let (s, elements) = ws(delimited(
+        stag!("mrow"),
+        many0(math_expression),
+        etag!("mrow"),
+    ))(input)?;
+    Ok((s, Mrow(elements)))
+}
+
+/// Parser for math expressions. This varies from the one in the generic_mathml module, since it
+/// assumes that expressions such as S(t) are actually univariate functions.
+pub fn math_expression(input: Span) -> IResult<MathExpression> {
+    ws(alt((
+        map(ci_univariate_func, MathExpression::Ci),
+        map(ci_unknown, |Ci { content, .. }| {
+            MathExpression::Ci(Ci {
+                r#type: Some(Type::Function),
+                content,
+            })
+        }),
+        map(operator, MathExpression::Mo),
+        mn,
+        msup,
+        msub,
+        msqrt,
+        mfrac,
+        map(mrow, MathExpression::Mrow),
+        msubsup,
+    )))(input)
+}
+
+/// Parser for interpreted math expressions.
+/// testing MathML documents
+pub fn interpreted_math(input: Span) -> IResult<Math> {
+    let (s, elements) = preceded(opt(xml_declaration), elem_many0!("math"))(input)?;
+    Ok((s, Math { content: elements }))
+}

--- a/skema/skema-rs/skema/src/services/mathml.rs
+++ b/skema/skema-rs/skema/src/services/mathml.rs
@@ -22,9 +22,6 @@ use utoipa;
 pub async fn get_ast_graph(payload: String) -> String {
     let contents = &payload;
     let math = contents.parse::<Math>().unwrap();
-    //let (_, math) =
-    //parse(contents).unwrap_or_else(|_| panic!("{}", "Unable to parse payload!".to_string()));
-
     let g = math.to_graph();
     let dot_representation = Dot::with_config(&g, &[Config::EdgeNoLabel]);
     dot_representation.to_string()
@@ -68,8 +65,7 @@ pub async fn get_math_exp_graph(payload: String) -> String {
 #[put("/mathml/content-mathml")]
 pub async fn get_content_mathml(payload: String) -> String {
     let ode = payload.parse::<FirstOrderODE>().unwrap();
-    let content_mathml = ode.to_cmml();
-    content_mathml
+    ode.to_cmml()
 }
 
 /// Return a JSON representation of a PetriNet ModelRep constructed from an array of MathML strings.


### PR DESCRIPTION
This PR implements support for parsing presentation MathML in general with a small amount of preliminary interpretation (e.g., Globbing `S(t)` to produce the identifier `S`. Previously, this functionality was restricted to first order ODE parsing, but has been extended to parsing arbitrary expressions as well. This is the default behavior when `MathExpressionTree` structs are constructed from strings. The interpreting parsers are in `interpreted_mathml.rs`

The previous 'non-interpreting' parsers are still available in `generic_mathml.rs`, and are kept for compatibility with ISA code. Some of them are also reused in `interpreted_mathml.rs`