### PR TITLE
[code2fn] - Support for Fortran Record Idiom and TS2CAST enchancements

### DIFF
--- a/skema/program_analysis/TS2CAST/node_helper.py
+++ b/skema/program_analysis/TS2CAST/node_helper.py
@@ -4,32 +4,33 @@ from skema.program_analysis.CAST2FN.model.cast import SourceRef
 from tree_sitter import Node
 
 CONTROL_CHARACTERS = [
-            ",",
-            "=",
-            "(",
-            ")",
-            "(/",
-            "/)",
-            ":",
-            "::",
-            "+",
-            "-",
-            "*",
-            "**",
-            "/",
-            ">",
-            "<",
-            "<=",
-            ">=",
-            "only"
+    ",",
+    "=",
+    "(",
+    ")",
+    "(/",
+    "/)",
+    ":",
+    "::",
+    "+",
+    "-",
+    "*",
+    "**",
+    "/",
+    ">",
+    "<",
+    "<=",
+    ">=",
+    "only",
 ]
 
+
 def fix_continuation_lines(source: str) -> str:
-    '''
+    """
     Preprocesses Fortran source code to convert continuation lines to tree-sitter supported format:
     1. Replaces the first occurrence of '|' with '&' if it is the first non-whitespace character in the line.
     2. Adds an additional '&' to the previous line
-    '''
+    """
     processed_lines = []
     for i, line in enumerate(source.splitlines()):
         if line.lstrip().startswith("|"):
@@ -37,21 +38,24 @@ def fix_continuation_lines(source: str) -> str:
             processed_lines[-1] += "&"
         processed_lines.append(line)
     return "\n".join(processed_lines)
-    
-def remove_comment_nodes(node:Node) -> Node:
-    '''
+
+
+def remove_comment_nodes(node: Node) -> Node:
+    """
     Recursivley walk through tree, removing and Comment nodes
-    '''
+    """
     [remove_comment_nodes(child) for child in node.children if child.type != "comment"]
 
+
 def get_source_ref(node: Node, file_name: str) -> SourceRef:
-    '''Given a node and file name, return a CAST SourceRef object.'''
+    """Given a node and file name, return a CAST SourceRef object."""
     row_start, col_start = node.start_point
     row_end, col_end = node.end_point
     return SourceRef(file_name, col_start, col_end, row_start, row_end)
 
+
 def get_identifier(node: Node, source: str) -> str:
-    '''Given a node, return the identifier it represents. ie. The code between node.start_point and node.end_point'''
+    """Given a node, return the identifier it represents. ie. The code between node.start_point and node.end_point"""
     line_num = 0
     column_num = 0
     in_identifier = False
@@ -71,22 +75,49 @@ def get_identifier(node: Node, source: str) -> str:
         if in_identifier:
             identifier += char
 
-    
     return identifier
 
-def get_first_child_by_type(node: Node, type: str):
-    '''Takes in a node and a type string as inputs and returns the first child matching that type. Otherwise, return None'''
+
+def get_first_child_by_type(node: Node, type: str, recurse=False):
+    """Takes in a node and a type string as inputs and returns the first child matching that type. Otherwise, return None
+    When the recurse argument is set, it will also recursivly search children nodes as well.
+    """
     for child in node.children:
         if child.type == type:
             return child
+
+    if recurse:
+        for child in node.children:
+            out = get_first_child_by_type(child, type, True)
+            if out:
+                return out
     return None
 
+
 def get_children_by_types(node: Node, types: List):
-    '''Takes in a node and a list of types as inputs and returns all children matching those types. Otherwise, return an empty list'''
+    """Takes in a node and a list of types as inputs and returns all children matching those types. Otherwise, return an empty list"""
     return [child for child in node.children if child.type in types]
 
-def get_control_children(node: Node): 
+
+def get_first_child_index(node, type: str):
+    """Get the index of the first child of node with type type."""
+    for i, child in enumerate(node.children):
+        if child.type == type:
+            return i
+
+
+def get_last_child_index(node, type: str):
+    """Get the index of the last child of node with type type."""
+    last = None
+    for i, child in enumerate(node.children):
+        if child.type == type:
+            last = child
+    return last
+
+
+def get_control_children(node: Node):
     return get_children_by_types(node, CONTROL_CHARACTERS)
+
 
 def get_non_control_children(node: Node):
     children = []

--- a/skema/program_analysis/TS2CAST/node_helper.py
+++ b/skema/program_analysis/TS2CAST/node_helper.py
@@ -6,6 +6,7 @@ from tree_sitter import Node
 CONTROL_CHARACTERS = [
     ",",
     "=",
+    "==",
     "(",
     ")",
     "(/",
@@ -24,59 +25,41 @@ CONTROL_CHARACTERS = [
     "only",
 ]
 
-
-def fix_continuation_lines(source: str) -> str:
-    """
-    Preprocesses Fortran source code to convert continuation lines to tree-sitter supported format:
-    1. Replaces the first occurrence of '|' with '&' if it is the first non-whitespace character in the line.
-    2. Adds an additional '&' to the previous line
-    """
-    processed_lines = []
-    for i, line in enumerate(source.splitlines()):
-        if line.lstrip().startswith("|"):
-            line = line.replace("|", "&", 1)
-            processed_lines[-1] += "&"
-        processed_lines.append(line)
-    return "\n".join(processed_lines)
+class NodeHelper():
+    def __init__(self, source: str, source_file_name: str):
+        self.source = source
+        self.source_file_name = source_file_name
 
 
-def remove_comment_nodes(node: Node) -> Node:
-    """
-    Recursivley walk through tree, removing and Comment nodes
-    """
-    [remove_comment_nodes(child) for child in node.children if child.type != "comment"]
+    def get_source_ref(self, node: Node) -> SourceRef:
+        """Given a node and file name, return a CAST SourceRef object."""
+        row_start, col_start = node.start_point
+        row_end, col_end = node.end_point
+        return SourceRef(self.source_file_name, col_start, col_end, row_start, row_end)
 
 
-def get_source_ref(node: Node, file_name: str) -> SourceRef:
-    """Given a node and file name, return a CAST SourceRef object."""
-    row_start, col_start = node.start_point
-    row_end, col_end = node.end_point
-    return SourceRef(file_name, col_start, col_end, row_start, row_end)
+    def get_identifier(self, node: Node) -> str:
+        """Given a node, return the identifier it represents. ie. The code between node.start_point and node.end_point"""
+        line_num = 0
+        column_num = 0
+        in_identifier = False
+        identifier = ""
+        for i, char in enumerate(self.source):
+            if line_num == node.start_point[0] and column_num == node.start_point[1]:
+                in_identifier = True
+            elif line_num == node.end_point[0] and column_num == node.end_point[1]:
+                break
 
+            if char == "\n":
+                line_num += 1
+                column_num = 0
+            else:
+                column_num += 1
 
-def get_identifier(node: Node, source: str) -> str:
-    """Given a node, return the identifier it represents. ie. The code between node.start_point and node.end_point"""
-    line_num = 0
-    column_num = 0
-    in_identifier = False
-    identifier = ""
-    for i, char in enumerate(source):
-        if line_num == node.start_point[0] and column_num == node.start_point[1]:
-            in_identifier = True
-        elif line_num == node.end_point[0] and column_num == node.end_point[1]:
-            break
+            if in_identifier:
+                identifier += char
 
-        if char == "\n":
-            line_num += 1
-            column_num = 0
-        else:
-            column_num += 1
-
-        if in_identifier:
-            identifier += char
-
-    return identifier
-
+        return identifier
 
 def get_first_child_by_type(node: Node, type: str, recurse=False):
     """Takes in a node and a type string as inputs and returns the first child matching that type. Otherwise, return None

--- a/skema/program_analysis/TS2CAST/preprocessor/preprocess.py
+++ b/skema/program_analysis/TS2CAST/preprocessor/preprocess.py
@@ -2,7 +2,9 @@ import argparse
 import re
 import os
 import shutil
-from typing import List
+import logging
+from typing import List, Optional
+from pathlib import Path
 from subprocess import run, PIPE
 
 from tree_sitter import Parser, Node, Language, Tree
@@ -13,8 +15,8 @@ from skema.program_analysis.TS2CAST.build_tree_sitter_fortran import (
 
 
 def preprocess(
-    source_path: str,
-    out_path: str,
+    source_path: Path,
+    out_dir=None,
     overwrite=False,
     out_missing_includes=False,
     out_gcc=False,
@@ -29,42 +31,45 @@ def preprocess(
     3. A log of unsupported idioms
     4. The source code with unsupported idioms corrected
     """
-
-    source = open(source_path, "r").read()
-    source_file_name = os.path.basename(source_path).split(".")[0]
-    source_directory = os.path.dirname(source_path)
-    include_base_directory = os.path.join(
-        source_directory, f"include_{source_file_name}"
-    )
-
     # NOTE: The order of preprocessing steps does matter. We have to run the GCC preprocessor before correcting the continuation lines or there could be issues
-    try:
-        os.mkdir(out_path)
-    except FileExistsError:
-        if not overwrite:
-            exit()
+
+    source = source_path.read_text()
+
+    # Get paths for intermediate products
+    if out_dir:
+        if not (out_missing_includes or out_gcc or out_unsupported or out_corrected):
+            logging.warning("out_dir is specified, but no out flags are set")
+
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        missing_includes_path = Path(out_dir, "missing_includes.txt")
+        gcc_path = Path(out_dir, "gcc.F")
+        unsupported_path = Path(out_dir, "unsupported_idioms.txt")
+        corrected_path = Path(out_dir, "corrected.F")
+        parse_path = Path(out_dir, "parse_tree.txt")
 
     # Step 1: Check for missing included files
-    missing_includes = check_for_missing_includes(source_path)
-    if out_missing_includes:
-        missing_includes_path = os.path.join(out_path, "missing_includes.txt")
-        with open(missing_includes_path, "w") as f:
-            f.write("\n".join(missing_includes))
-    if len(missing_includes) > 0:
-        print("Missing required included files, missing files were:")
-        for include in missing_includes:
-            print(include)
-        exit()
+    # Many source files won't have includes. We only need to check missing includes if a source contains an include statement.
+    if len(produce_include_summary(source)) > 0:
+        missing_includes = check_for_missing_includes(source_path)
+        if out_missing_includes:
+            missing_includes_path.write_text("\n".join(missing_includes))
+
+        if len(missing_includes) > 0:
+            logging.error("Missing required included files, missing files were:")
+            for include in missing_includes:
+                logging.error(include)
+            exit()
+    elif out_missing_includes:
+        missing_includes_path.write_text("Source file contains no include statements")
 
     # Step 2: Correct include directives to remove system references
     source = fix_include_directives(source)
 
     # Step 3: Process with gcc c-preprocessor
-    source = run_c_preprocessor(source, include_base_directory)
+    source = run_c_preprocessor(source, source_path.parent)
     if out_gcc:
-        gcc_path = os.path.join(out_path, "gcc.F")
-        with open(gcc_path, "w") as f:
-            f.write(source)
+        gcc_path.write_text(source)
 
     # Step 4: Prepare for tree-sitter
     # This step removes any additional preprocessor directives added or not removed by GCC
@@ -74,46 +79,41 @@ def preprocess(
 
     # Step 5: Check for unsupported idioms
     if out_unsupported:
-        unsupported_path = os.path.join(out_path, "unsupported_idioms.txt")
-        with open(unsupported_path, "w") as f:
-            f.writelines(search_for_unsupported_idioms(source, "idioms_regex.txt"))
+        unsupported_path.write_text(
+            "\n".join(search_for_unsupported_idioms(source, "idioms_regex.txt"))
+        )
 
     # Step 6 : Fix unsupported idioms
     source = fix_unsupported_idioms(source)
     if out_corrected:
-        corrected_path = os.path.join(out_path, "corrected.F")
-        with open(corrected_path, "w") as f:
-            f.write(source)
+        corrected_path.write_text(source)
 
     return source
 
 
-def check_for_missing_includes(source_path: str):
+def produce_include_summary(source: str) -> List:
+    """Uses regex to produce a list of all included files in a source"""
+    includes = []
+
+    system_re = "#include\s+<(.*)>"
+    local_re = '#include\s+"(.*)"'
+
+    for match in re.finditer(system_re, source):
+        includes.append(match.group(1))
+    for match in re.finditer(local_re, source):
+        includes.append(match.group(1))
+
+    return includes
+
+
+def check_for_missing_includes(source_path: Path):
     """Gathers all required includes and check if they have been added to the include_SOURCE directory"""
-
-    def produce_include_summary(source: str) -> List:
-        """Uses regex to produce a list of all included files in a source"""
-        includes = []
-
-        system_re = "#include\s+<(.*)>"
-        local_re = '#include\s+"(.*)"'
-
-        for match in re.finditer(system_re, source):
-            includes.append(match.group(1))
-        for match in re.finditer(local_re, source):
-            includes.append(match.group(1))
-
-        return includes
 
     missing_files = []
 
     # First we will check for the include directory
-    source_file_name = os.path.basename(source_path).split(".")[0]
-    source_directory = os.path.dirname(source_path)
-    include_base_directory = os.path.join(
-        source_directory, f"include_{source_file_name}"
-    )
-    if not os.path.isdir(include_base_directory):
+    include_base_directory = Path(source_path.parent, f"include_{source_path.stem}")
+    if not include_base_directory.exists():
         missing_files.append(include_base_directory)
         return missing_files
 
@@ -124,7 +124,7 @@ def check_for_missing_includes(source_path: str):
     includes = []
     for dirpath, dirnames, filenames in os.walk(include_base_directory):
         for file in filenames:
-            file_source = open(os.path.join(dirpath, file), "r").read()
+            file_source = Path(dirpath, file).read_text()
             includes.extend(produce_include_summary(file_source))
 
     # Check for missing files
@@ -132,7 +132,7 @@ def check_for_missing_includes(source_path: str):
     for include in includes:
         if include in already_checked:
             continue
-        if not os.path.isfile(os.path.join(include_base_directory, include)):
+        if not Path(include_base_directory, include).exists():
             missing_files.append(include)
         already_checked.add(include)
     return missing_files
@@ -145,10 +145,9 @@ def search_for_unsupported_idioms(source: str, idioms_regex_path: str):
     for line in lines:
         for match in re.finditer(line, source, flags=re.MULTILINE):
             line_number = source[: match.span()[0]].count("\n")
-            log.append(f"Found unsupported idiom matching regex: {line}" + "\n")
-            log.append(f"Match was: {match.group(0)}" + "\n")
-            log.append(f"Line was: {line_number}" + "\n")
-            log.append(f"\n")
+            log.append(f"Found unsupported idiom matching regex: {line}")
+            log.append(f"Match was: {match.group(0)}")
+            log.append(f"Line was: {line_number}")
     return log
 
 
@@ -183,7 +182,7 @@ def fix_include_directives(source: str) -> str:
     return source
 
 
-def run_c_preprocessor(source: str, include_base_path: str) -> str:
+def run_c_preprocessor(source: str, include_base_path: Path) -> str:
     """Run the gcc c-preprocessor. Its run from the context of the include_base_path, so that it can find all included files"""
     result = run(
         ["gcc", "-cpp", "-E", "-"],
@@ -195,11 +194,12 @@ def run_c_preprocessor(source: str, include_base_path: str) -> str:
     )
     return result.stdout
 
+
 def main():
     """Run the preprocessor as a script"""
     parser = argparse.ArgumentParser(description="Fortran preprocessing script")
     parser.add_argument("source_path", type=str, help="Path to the source file")
-    parser.add_argument("out_path", type=str, help="Output directory path")
+    parser.add_argument("out_dir", type=str, help="Output directory path")
     parser.add_argument(
         "-o",
         "--overwrite",
@@ -229,13 +229,13 @@ def main():
     args = parser.parse_args()
 
     preprocess(
-        args.source_path,
-        args.out_path,
+        Path(args.source_path),
+        Path(args.out_dir),
         args.overwrite,
         args.out_missing_includes,
         args.out_gcc,
         args.out_unsupported,
-        args.out_corrected
+        args.out_corrected,
     )
 
 

--- a/skema/program_analysis/TS2CAST/ts2cast.py
+++ b/skema/program_analysis/TS2CAST/ts2cast.py
@@ -64,8 +64,6 @@ class TS2CAST(object):
 
         # Start visiting
         self.out_cast = self.generate_cast()
- 
-        print(json.dumps(self.out_cast[0].to_json_object(), sort_keys=True, indent=None))
 
     def generate_cast(self) -> List[CAST]:
         '''Interface for generating CAST.'''
@@ -1107,5 +1105,3 @@ class TS2CAST(object):
             return self.variable_context.get_node(func_name)
 
         return self.variable_context.add_variable(func_name, "function", None)
-
-TS2CAST("cons.f95")

--- a/skema/program_analysis/TS2CAST/ts2cast.py
+++ b/skema/program_analysis/TS2CAST/ts2cast.py
@@ -84,16 +84,24 @@ class TS2CAST(object):
         for context in contexts:
             modules.append(self.visit(context))
 
-        '''
-        self.module.source_refs = [self.node_helper.get_source_ref(root)]
-        self.module.body = []
-        for child in root.children:
-            child_cast = self.visit(child)
-            if isinstance(child_cast, List):
-                self.module.body.extend(child_cast)
-            else:
-                self.module.body.append(child_cast)
-        '''
+        # Currently, we are supporting functions and subroutines defined outside of programs and modules
+        # Other than comments, it is unclear if anything else is allowed.
+        # TODO: Research the above
+        outer_body_nodes = get_children_by_types(root, ["function", "subroutine"])
+        if len(outer_body_nodes) > 0:
+            body = []
+            for body_node in outer_body_nodes:
+                child_cast = self.visit(body_node)
+                if isinstance(child_cast, List):
+                    body.extend(child_cast)
+                elif isinstance(child_cast, AstNode):
+                    body.append(child_cast)
+            modules.append(Module(
+                name=None,
+                body=body,
+                source_refs=[self.node_helper.get_source_ref(root)]
+            ))
+    
         return modules
 
     def visit(self, node):

--- a/skema/program_analysis/TS2CAST/ts2cast.py
+++ b/skema/program_analysis/TS2CAST/ts2cast.py
@@ -2,7 +2,7 @@ import json
 import os.path
 from typing import Any, Dict, List
 
-from tree_sitter import Language, Parser
+from tree_sitter import Language, Parser, Node
 
 from skema.program_analysis.CAST2FN.cast import CAST
 from skema.program_analysis.CAST2FN.model.cast import (
@@ -26,7 +26,7 @@ from skema.program_analysis.CAST2FN.model.cast import (
 
 
 from skema.program_analysis.TS2CAST.variable_context import VariableContext
-from skema.program_analysis.TS2CAST.node_helper import NodeHelper
+from skema.program_analysis.TS2CAST.node_helper import get_children_by_types, get_identifier, get_source_ref, get_first_child_by_type, get_control_children, get_non_control_children, fix_continuation_lines
 from skema.program_analysis.TS2CAST.util import generate_dummy_source_refs, preprocess
 
 from skema.program_analysis.TS2CAST.build_tree_sitter_fortran import LANGUAGE_LIBRARY_REL_PATH
@@ -38,9 +38,9 @@ class TS2CAST(object):
         self.tree_sitter_fortran = Language(tree_sitter_fortran_path, "fortran")
 
         # We load the source code from a file
-        self.source = None
         with open(source_file_path, "r") as f:
             self.source = f.read()
+        self.source = fix_continuation_lines(self.source)
 
         # Set up tree sitter parser
         self.parser = Parser()
@@ -55,73 +55,69 @@ class TS2CAST(object):
         # Walking data
         self.variable_context = VariableContext()
 
-        self.node_helper = NodeHelper(source_file_path, self.source)
-        self.parse_dict = self.node_helper.parse_tree_to_dict(self.tree.root_node)
-        # print(json.dumps(self.parse_dict))
-
         # Start visiting
-        self.run(self.parse_dict)
+        self.run(self.tree.root_node)
 
         generate_dummy_source_refs(self.module)
 
         # Create outer cast wrapping
         self.out_cast = CAST([self.module], "Fortran")
-        # print(
-        #            json.dumps(
-        #               out_cast.to_json_object(), sort_keys=True, indent=None
-        #            )
-        #        )
+        print(
+                json.dumps(
+                       self. out_cast.to_json_object(), sort_keys=True, indent=None
+                )
+            )
 
-    def run(self, root: Dict):
-        self.module.source_refs = root["source_refs"]
+    def run(self, root):
+        self.module.source_refs = [get_source_ref(root, self.source_file_name)]
         self.module.body = []
-        for child in root["children"]:
+        for child in root.children:
             child_cast = self.visit(child)
             if isinstance(child_cast, List):
                 self.module.body.extend(child_cast)
             else:
                 self.module.body.append(child_cast)
 
-    def visit(self, node: Dict):
-        if node["type"] == "program":
+    def visit(self, node):
+        if node.type == "program":
             return self.visit_program_statement(node)
-        elif node["type"] in ["subroutine", "function"]:
+        elif node.type in ["subroutine", "function"]:
             return self.visit_function_def(node)
-        elif node["type"] in ["subroutine_call", "call_expression"]:
+        elif node.type in ["subroutine_call", "call_expression"]:
             return self.visit_function_call(node)
-        elif node["type"] == "use_statement":
+        elif node.type == "use_statement":
             return self.visit_use_statement(node)
-        elif node["type"] == "variable_declaration":
+        elif node.type == "variable_declaration":
             return self.visit_variable_declaration(node)
-        elif node["type"] == "assignment_statement":
+        elif node.type == "assignment_statement":
             return self.visit_assignment_statement(node)
-        elif node["type"] == "identifier":
+        elif node.type == "identifier":
             return self.visit_identifier(node)
-        elif node["type"] == "name":
+        elif node.type == "name":
             return self.visit_name(node)
-        elif node["type"] in ["math_expression", "relational_expression"]:
+        elif node.type in ["math_expression", "relational_expression"]:
             return self.visit_math_expression(node)
-        elif node["type"] in [
+        elif node.type in [
             "number_literal",
             "array_literal",
             "string_literal",
             "boolean_literal",
         ]:
             return self.visit_literal(node)
-        elif node["type"] == "keyword_statement":
+        elif node.type == "keyword_statement":
             return self.visit_keyword_statement(node)
-        elif node["type"] == "extent_specifier":
+        elif node.type == "extent_specifier":
             return self.visit_extent_specifier(node)
-        elif node["type"] == "do_loop_statement":
+        elif node.type == "do_loop_statement":
             return self.visit_do_loop_statement(node)
-        elif node["type"] == "if_statement":
+        elif node.type == "if_statement":
             return self.visit_if_statement(node)
         else:
             return self._visit_passthrough(node)
 
     def visit_program_statement(self, node):
         program_body = []
-        for child in node["children"][1:]:
+        for child in node.children[1:]:
             child_cast = self.visit(child)
             if isinstance(child_cast, List):
                 program_body.extend(child_cast)
@@ -132,14 +128,14 @@ class TS2CAST(object):
     def visit_name(self, node):
         # Node structure
         # (name)
-        assert len(node["children"]) == 0
 
-        # First, we will check if this name is already defined, and if it is
-        if self.variable_context.is_variable(node["identifier"]):
-            return self.variable_context.get_node(node["identifier"])
+        # First, we will check if this name is already defined, and if it is return the name node generated previously
+        identifier = get_identifier(node, self.source)
+        if self.variable_context.is_variable(identifier):
+            return self.variable_context.get_node(identifier)
 
         return self.variable_context.add_variable(
-            node["identifier"], "Unknown", node["source_refs"]
+            identifier, "Unknown", [get_source_ref(node, self.source_file_name)]
         )
 
     def visit_function_def(self, node):
@@ -164,91 +160,88 @@ class TS2CAST(object):
         self.variable_context.push_context()
 
         # Top level statement node
-        statement_node = node["children"][0]
-        name_node = self.node_helper.get_first_child_by_type(statement_node, "name")
-        self.visit(name_node)  # Visit the name node
+        statement_node = get_first_child_by_type(node, "subroutine_statement")
+        name_node = get_first_child_by_type(statement_node, "name")
+        name = self.visit(name_node)  # Visit the name node to add it to the variable context 
 
         # If this is a function, check for return type and return value
         intrinsic_type = None
         return_value = None
-        if node["type"] == "function":
-            if intrinsic_type_node := self.node_helper.get_first_child_by_type(
-                statement_node, "intrinsic_type"
-            ):
-                intrinsic_type = intrinsic_type_node["identifier"]
-                self.variable_context.add_variable(
-                    name_node["identifier"], intrinsic_type, None
-                )
-            if return_value_node := self.node_helper.get_first_child_by_type(
-                statement_node, "function_result"
-            ):
-                return_value = self.visit(return_value_node["children"][1])
-                self.variable_context.add_return_value(return_value.val.name)
-            else:
-                # #TODO: What happens if function doesn't return anything?
-                # If this is a function, and there is no explicit results variable, then we will assume the return value is the name of the function
-                self.variable_context.add_return_value(name_node["identifier"])
+        if node.type == "function":
+            signature_qualifiers = get_children_by_types(statement_node, ["intrinsic_type", "function_result"])
+            for qualifier in signature_qualifiers:
+                if qualifier.type == "intrinsic_type":
+                    intrinsic_type = get_identifier(qualifier, self.source)
+                    self.variable_context.add_variable(get_identifier(name_node, self.source), intrinsic_type, None)
+                elif qualifier.type == "function_result":
+                    return_value = self.visit(qualifier.children[0]) #TODO: UPDATE NODES
+                    self.variable_context.add_return_value(return_value.val.name)
+
+        # #TODO: What happens if function doesn't return anything?
+        # If this is a function, and there is no explicit results variable, then we will assume the return value is the name of the function
+        if not return_value:
+            self.variable_context.add_return_value(get_identifier(name_node, self.source))
 
         # If funciton has both, then we also need to update the type of the return value in the variable context
         # It does not explicity have to be declared
         if return_value and intrinsic_type:
             self.variable_context.update_type(return_value.val.name, intrinsic_type)
 
-        cast_func = FunctionDef()
-        cast_func.source_refs = node["source_refs"]
-        cast_func.func_args = []
-        cast_func.body = []
-        cast_func.name = self.visit(name_node)
-
         # Generating the function arguments by walking the parameters node
-        parameters_node = self.node_helper.get_first_child_by_type(
-            statement_node, "parameters"
-        )
-        if parameters_node:
-            for child in parameters_node["children"]:
+        func_args = []
+        if parameters_node := get_first_child_by_type(statement_node, "parameters"):
+            for parameter in get_non_control_children(parameters_node):
                 # For both subroutine and functions, all arguments are assumes intent(inout) by default unless otherwise specified with intent(in)
                 # The variable declaration visitor will check for this and remove any arguments that are input only from the return values
-                self.variable_context.add_return_value(child["identifier"])
-
-                cast_func.func_args = TS2CAST.update_field(
-                    cast_func.func_args, self.visit(child)
-                )
+                self.variable_context.add_return_value(get_identifier(parameter, self.source))
+                func_args.append(self.visit(parameter))
 
         # The first child of function will be the function statement, the rest will be body nodes
-        for child in node["children"][1:]:
-            cast_func.body = TS2CAST.update_field(cast_func.body, self.visit(child))
-
+        body = []
+        for body_node in node.children[1:]:
+            child_cast = self.visit(body_node)
+            if isinstance(child_cast, List):
+                body.extend(child_cast)
+            else:
+                body.append(child_cast)
+       
         # After creating the body, we can go back and update the var nodes we created for the arguments
         # We do this by looking for intent,in nodes
-        for i, arg in enumerate(cast_func.func_args):
-            cast_func.func_args[i].type = self.variable_context.get_type(arg.val.name)
+        for i, arg in enumerate(func_args):
+            #print(func_args)
+            func_args[i].type = self.variable_context.get_type(arg.val.name)
 
         # TODO:
         # This logic can be made cleaner
         # Fortran doesn't require a return statement, so we need to check if there is a top-level return statement
         # If there is not, then we will create a dummy one
         return_found = False
-        for child in cast_func.body:
+        for child in body:
             if isinstance(child, ModelReturn):
                 return_found = True
         if not return_found:
-            cast_func.body.append(self.visit_keyword_statement(node))
+            body.append(self.visit_keyword_statement(node))
 
         # Pop variable context off of stack before leaving this scope
         self.variable_context.pop_context()
 
-        return cast_func
+        return FunctionDef(
+            name=name,
+            func_args=func_args,
+            body=body,
+            source_refs=[get_source_ref(node, self.source_file_name)]
+        )
 
     def visit_function_call(self, node):
         # Pull relevent nodes
-        if node["type"] == "subroutine_call":
-            function_node = node["children"][1]
-            arguments_node = node["children"][2]
-        elif node["type"] == "call_expression":
-            function_node = node["children"][0]
-            arguments_node = node["children"][1]
+        if node.type == "subroutine_call":
+            function_node = node.children[1] 
+            arguments_node = node.children[2]
+        elif node.type == "call_expression":
+            function_node = node.children[0]
+            arguments_node = node.children[1]
 
-        function_identifier = function_node["identifier"]
+        function_identifier = get_identifier(function_node, self.source)
 
         # Tree-Sitter incorrectly parses mutlidimensional array accesses as function calls
         # We will need to check if this is truly a function call or a subscript
@@ -258,28 +251,29 @@ class TS2CAST(object):
                     node
                 )  # This overrides the visitor and forces us to visit another
 
-        cast_call = Call()
-        cast_call.source_refs = node["source_refs"]
-
         # TODO: What should get a name node? Instrincit functions? Imported functions?
         # Judging from the Gromet generation pipeline, it appears that all functions need Name nodes.
         if self.variable_context.is_variable(function_identifier):
-            cast_call.func = self.variable_context.get_node(function_identifier)
+            func = self.variable_context.get_node(function_identifier)
         else:
-            cast_call.func = Name(function_identifier, -1)
+            func = Name(function_identifier, -1) #TODO: REFACTOR
 
         # Add arguments to arguments list
-        for child in arguments_node["children"]:
-            cast_call.arguments = TS2CAST.update_field(
-                cast_call.arguments, self.visit(child)
-            )
+        arguments = []
+        for argument in arguments_node.children:
+            arguments.append(self.visit(argument))
 
-        return cast_call
+        return Call(
+            func=func,
+            source_language="Fortran",
+            source_language_version="2008",
+            arguments = arguments,
+            source_refs=[get_source_ref(node, self.source_file_name)]
+        )
 
     def visit_keyword_statement(self, node):
         # Currently, the only keyword_identifier produced by tree-sitter is Return
         # However, there may be other instances
-        cast_return = ModelReturn(source_refs=node["source_refs"])
 
         # In Fortran the return statement doesn't return a value (there is the obsolete "alternative return")
         # We keep track of values that need to be returned in the variable context
@@ -288,59 +282,70 @@ class TS2CAST(object):
         ]  # TODO: Make function for this
 
         if len(return_values) == 1:
-            cast_return.value = self.variable_context.get_node(return_values[0])
+            #TODO: Fix this case
+            value = self.variable_context.get_node(return_values[0])
         elif len(return_values) > 1:
-            cast_tuple = LiteralValue("Tuple", [])
-
-            for return_value in return_values:
-                cast_var = Var()
-                cast_var.val = self.variable_context.get_node(return_value)
-                cast_var.type = self.variable_context.get_type(return_value)
-                cast_tuple.value.append(cast_var)
-            cast_return.value = cast_tuple
+            value = LiteralValue(
+                value_type="Tuple",
+                value=[Var(
+                    val=self.variable_context.get_node(ret),
+                    type=self.variable_context.get_type(ret),
+                    default_value=None,
+                    source_refs=None
+                ) for ret in return_values],
+                source_code_data_type=None, #TODO: REFACTOR
+                source_refs = None
+            )
         else:
-            cast_return.value = LiteralValue(None, None)
+            value = LiteralValue(
+                val=None, 
+                type=None,
+                source_refs=None
+            )
 
-        return cast_return
-
-    def visit_use_statement(self, node):
-        ## Pull relevent child nodes
-        module_name_node = node["children"][0]
-        included_items_nodes = self.node_helper.get_children_by_type(
-            node,
-            "included_items",
+        return ModelReturn(
+            value=value,
+            source_refs=[get_source_ref(node, self.source_file_name)]
         )
 
-        import_all = len(included_items_nodes) == 0
+    def visit_use_statement(self, node):
+        # (use)
+        #   (use)
+        #   (module_name)
+    
+        ## Pull relevent child nodes  
+        module_name_node = get_first_child_by_type(node, "module_name")
+        module_name = get_identifier(module_name_node, self.source)
+        included_items_node = get_first_child_by_type(node, "included_items")
+
+        import_all = included_items_node is None
         import_alias = None  # TODO: Look into local-name and use-name fields
 
         # We need to check if this import is a full import of a module, i.e. use module
         # Or a partial import i.e. use module,only: sub1, sub2
         if import_all:
-            cast_import = ModelImport()
-            cast_import.source_refs = node["source_refs"]
-            cast_import.name = module_name_node["identifier"]
-            cast_import.alias = import_alias
-            cast_import.all = import_all
-            cast_import.symbol = None
-
-            return cast_import
+            return ModelImport(
+                name=module_name,
+                alias=import_alias,
+                all=import_all,
+                symbol=None,
+                source_refs=None
+            )
         else:
             imports = []
-            for child in included_items_nodes[0]["children"]:
-                cast_import = ModelImport()
-                cast_import.source_refs = child["source_refs"]
-                cast_import.name = module_name_node["identifier"]
-                cast_import.alias = import_alias
-                cast_import.all = import_all
-                cast_import.symbol = child["identifier"]
-
-                # Add the symbol to the variable context
-                self.variable_context.add_variable(
-                    cast_import.symbol, "function", child["source_refs"]
+            for symbol in get_non_control_children(included_items_node):
+                symbol_identifier = get_identifier(symbol, self.source)
+                symbol_source_refs = [get_source_ref(symbol, self.source_file_name)]
+                imports.append(
+                    ModelImport(
+                        name=module_name,
+                        alias=import_alias,
+                        all=import_all,
+                        symbol=symbol_identifier,
+                        source_refs=symbol_source_refs
+                    )
                 )
 
-                imports.append(cast_import)
             return imports
 
     def visit_do_loop_statement(self, node):
@@ -361,35 +366,30 @@ class TS2CAST(object):
         #      (...) ...
         #   (body) ...
         # print(self.variable_context.context)
-        assert len(node["children"]) > 2
-        loop_type = node["children"][1]["type"]
-
-        cast_loop = Loop()
-        cast_loop.source_refs = node["source_refs"]
-        cast_loop.pre = []
-        cast_loop.post = []
-        cast_loop.expr = None
-        cast_loop.body = []
+        loop_type = node.children[1].type #TODO: Implement while loop
 
         # The body will be the same for both loops, like the function definition, its simply every child node after the first
         # TODO: This may not be the case
-        for child in node["children"][2:]:
-            cast_loop.body = self.update_field(cast_loop.body, self.visit(child))
+        body = []
+        for body_node in node.children[2:]:
+            child_cast = self.visit(body_node)
+            if isinstance(child_cast, List):
+                body.extend(child_cast)
+            else:
+                body.append(child_cast)
 
         # For the init and expression fields, we first need to determine if we are in a regular "do" or a "do while" loop
-
         # PRE:
-        # TODO: Why is this different from the schema
         # _next(_iter(range(start, stop, step)))
-        loop_control_node = node["children"][1]
-        itterator = self.visit(loop_control_node["children"][0])
-        start = self.visit(loop_control_node["children"][1])
-        stop = self.visit(loop_control_node["children"][2])
-
-        if len(loop_control_node["children"]) == 3:  # No step value
+        loop_control_node = node.children[1]
+        itterator = self.visit(loop_control_node.children[0])
+        start = self.visit(loop_control_node.children[1])
+        stop = self.visit(loop_control_node.children[2])
+        step = None
+        if len(loop_control_node.children) == 3:  # No step value
             step = LiteralValue("Integer", "1")
-        elif len(loop_control_node["children"]) == 4:
-            step = self.visit(loop_control_node["children"][3])
+        elif len(loop_control_node.children) == 4:
+            step = self.visit(loop_control_node.children[3])
 
         range_name_node = self.get_gromet_function_node("range")
         iter_name_node = self.get_gromet_function_node("iter")
@@ -398,7 +398,8 @@ class TS2CAST(object):
         stop_condition_name_node = self.variable_context.generate_stop_condition()
 
         # generated_iter_0 = iter(range(start, stop, step))
-        cast_loop.pre.append(
+        pre = []
+        pre.append(
             Assignment(
                 left=Var(generated_iter_name_node, "Iterator"),
                 right=Call(
@@ -409,7 +410,7 @@ class TS2CAST(object):
         )
 
         # (i, generated_iter_0, sc_0) = next(generated_iter_0)
-        cast_loop.pre.append(
+        pre.append(
             Assignment(
                 left=LiteralValue(
                     "Tuple",
@@ -427,7 +428,8 @@ class TS2CAST(object):
         )
 
         # EXPR
-        cast_loop.expr = Operator(
+        expr = []
+        expr = Operator(
             op="!=",  # TODO: Should this be == or !=
             operands=[
                 Var(stop_condition_name_node, "Boolean"),
@@ -438,7 +440,7 @@ class TS2CAST(object):
         # BODY
         # At this point, the body nodes have already been visited
         # We just need to append the iterator next call
-        cast_loop.body.append(
+        body.append(
             Assignment(
                 left=LiteralValue(
                     "Tuple",
@@ -456,14 +458,21 @@ class TS2CAST(object):
         )
 
         # POST
-        cast_loop.post.append(
+        post = []
+        post.append(
             Assignment(
                 left=itterator,
                 right=Operator(op="+", operands=[itterator, step]),
             )
         )
 
-        return cast_loop
+        return Loop(
+            pre=pre,
+            expr=expr,
+            body=body,
+            post=post,
+            source_refs=[get_source_ref(node, self.source_file_name)]
+        )
 
     def visit_if_statement(self, node):
         # (if_statement)
@@ -475,7 +484,9 @@ class TS2CAST(object):
         #  (else_clause)
         #  (end_if_statement)
 
-        child_types = [child["type"] for child in node["children"]]
+        # First we need to identify if this is a componund conditional
+        # We can do this by counting the number of control characters in a relational expression
+        child_types = [child.type for child in node.children]
 
         try:
             elseif_index = child_types.index("elseif_clause")
@@ -498,9 +509,9 @@ class TS2CAST(object):
         if elseif_index != -1:
             orelse = ModelIf()
             prev = orelse
-            for condition in node["children"][elseif_index:else_index]:
-                elseif_expr = self.visit(condition["children"][2])
-                elseif_body = [self.visit(child) for child in condition["children"][4:]]
+            for condition in node.children[elseif_index:else_index]:
+                elseif_expr = self.visit(condition.children[2])
+                elseif_body = [self.visit(child) for child in condition.children[4:]]
 
                 prev.orelse = ModelIf(elseif_expr, elseif_body, None)
                 prev = prev.orelse
@@ -508,7 +519,7 @@ class TS2CAST(object):
         if else_index != -1:
             else_body = [
                 self.visit(child)
-                for child in node["children"][else_index]["children"][1:]
+                for child in node.children[else_index].children[1:]
             ]
             if prev:
                 prev.orelse = else_body
@@ -519,113 +530,109 @@ class TS2CAST(object):
             orelse = orelse.orelse
 
         return ModelIf(
-            expr=self.visit(node["children"][1]),
-            body=[self.visit(child) for child in node["children"][3:body_stop_index]],
+            expr=self.visit(node.children[1]),
+            body=[self.visit(child) for child in node.children[3:body_stop_index]],
             orelse=orelse,
         )
 
     def visit_assignment_statement(self, node):
-        cast_assignment = Assignment()
-        cast_assignment.source_refs = node["source_refs"]
-
-        assert len(node["children"]) == 2
-        left, right = node["children"]
+        left, _, right = node.children
 
         # We need to check if the left side is a multidimensional array,
         # Since tree-sitter incorrectly shows this assignment as a call_expression
-        if left["type"] == "call_expression":
+        if left.type == "call_expression":
             return self._visit_set(node)
 
-        cast_assignment.left = self.visit(left)
-        cast_assignment.right = self.visit(right)
-
-        return cast_assignment
+        return Assignment(
+            left=self.visit(left),
+            right=self.visit(right),
+            source_refs=[get_source_ref(node, self.source_file_name)]
+        )
 
     def visit_literal(self, node):
-        literal_type = node["type"]
-        literal_value = node["identifier"]
-
-        cast_literal = LiteralValue()
-        cast_literal.source_refs = node["source_refs"]
+        literal_type = node.type
+        literal_value = get_identifier(node, self.source)
+        literal_source_ref = get_source_ref(node, self.source_file_name)
 
         if literal_type == "number_literal":
             # Check if this is a real value, or an Integer
             if "e" in literal_value.lower() or "." in literal_value:
-                cast_literal.value_type = "AbstractFloat"
-                cast_literal.source_code_data_type = [
-                    "Fortran",
-                    "Fortran95",
-                    "real",
-                ]
+                return LiteralValue(
+                    value_type="AbstractFloat", 
+                    value=literal_value,
+                    source_code_data_type=["Fortran", "Fortran95", "real"],
+                    source_refs=[literal_source_ref])
             else:
-                cast_literal.value_type = "Integer"
-                cast_literal.source_code_data_type = [
-                    "Fortran",
-                    "Fortran95",
-                    "integer",
-                ]
-            cast_literal.value = literal_value
+                return LiteralValue(
+                    value_type="Integer",
+                    value=literal_value,
+                    source_code_data_type=["Fortran", "Fortran95", "integer"],
+                    source_refs=[literal_source_ref]
+                )
 
         elif literal_type == "string_literal":
-            cast_literal.value_type = "Character"
-            cast_literal.source_code_data_type = [
-                "Fortran",
-                "Fortran95",
-                "character",
-            ]
-            cast_literal.value = literal_value
+            return LiteralValue(
+                    value_type="Character",
+                    value=literal_value,
+                    source_code_data_type=["Fortran", "Fortran95", "character"],
+                    source_refs=[literal_source_ref]
+                )
 
         elif literal_type == "boolean_literal":
-            cast_literal.value_type = "Boolean"
-            cast_literal.source_code_data_type = ["Fortran", "Fortran95", "logical"]
-            cast_literal.value = literal_value
+            return LiteralValue(
+                    value_type="Boolean",
+                    value=literal_value,
+                    source_code_data_type=["Fortran", "Fortran95", "logical"],
+                    source_refs=[literal_source_ref]
+                )
 
+        # TODO: Create logic for array literal creation
         elif literal_type == "array_literal":
-            cast_literal.value_type = "List"
-            cast_literal.source_code_data_type = [
-                "Fortran",
-                "Fortran95",
-                "dimension",
-            ]
-            cast_literal.value = None
+            return LiteralValue(
+                    value_type="List",
+                    value=[self.visit(element) for element in get_non_control_children(node)],
+                    source_code_data_type=["Fortran", "Fortran95", "dimension"],
+                    source_refs=[literal_source_ref]
+                )
 
-        return cast_literal
 
     def visit_identifier(self, node):
-        cast_var = Var()
-        cast_var.source_refs = node["source_refs"]
-
         # By default, this is unknown, but can be updated by other visitors
-        if self.variable_context.is_variable(node["identifier"]):
-            cast_var.type = self.variable_context.get_type(node["identifier"])
+        identifier = get_identifier(node, self.source)
+        if self.variable_context.is_variable(identifier):
+            var_type = self.variable_context.get_type(identifier)
         else:
-            cast_var.type = "Unknown"
+            var_type = "Unknown"
 
         # Default value comes from Pytohn keyword arguments i.e. def foo(a, b=10)
         # Fortran does have optional arguments introduced in F90, but these do not specify a default
-        cast_var.default_value = None
+        default_value = None
 
         # This is another case where we need to override the visitor to explicitly visit another node
-        cast_var.val = self.visit_name(node)
+        value = self.visit_name(node)
 
-        return cast_var
+        return Var(
+            val=value,
+            type=var_type,
+            default_value=default_value,
+            source_refs=[get_source_ref(node, self.source_file_name)]
+        )
 
     def visit_math_expression(self, node):
-        op = node["control"][0]  # The operator will be the first control character
+        op = get_identifier(get_control_children(node)[0], self.source)  # The operator will be the first control character
 
-        cast_op = Operator()
-        cast_op.source_refs = node["source_refs"]
+        operands = []
+        for operand in get_non_control_children(node):
+            operands.append(self.visit(operand))
 
-        cast_op.source_language = "Fortran"
-        cast_op.interpreter = None
-        cast_op.version = None
-
-        cast_op.op = op["identifier"]
-
-        for child in node["children"]:
-            cast_op.operands = TS2CAST.update_field(cast_op.operands, self.visit(child))
-
-        return cast_op
+        return Operator(
+            source_language="Fortran",
+            interpreter=None,
+            version=None,
+            op=op,
+            operands=operands,
+            source_refs=[get_source_ref(node, self.source_file_name)]
+        )
 
     def visit_variable_declaration(self, node):
         # Node structure
@@ -638,7 +645,6 @@ class TS2CAST(object):
         #   (assignment_statement) ...
 
         # The type will be determined from the child intrensic_type node
-        # TODO: Expand this type map and move it somewhere else
         type_map = {
             "integer": "Integer",
             "real": "AbstractFloat",
@@ -646,50 +652,59 @@ class TS2CAST(object):
             "logical": "Boolean",
             "character": "String",
         }
+    
+        intrinsic_type = type_map[get_identifier(get_first_child_by_type(node, "intrinsic_type"), self.source)]
+        variable_intent = ""
 
-        intrinsic_type = type_map[node["children"][0]["identifier"]]
-        variable_intent = "TODO"
-
-        type_qualifiers = self.node_helper.get_children_by_type(node, "type_qualifier")
-        identifiers = self.node_helper.get_children_by_type(node, "identifier")
-        assignment_statements = self.node_helper.get_children_by_type(
-            node, "assignment_statement"
-        )
-
-        # We then need to determine if we are creating an array (dimension) or a single variable
-        for type_qualifier in type_qualifiers:
-            qualifier = type_qualifier["children"][0]["identifier"]
-            try:
-                value = type_qualifier["children"][1]["identifier"]
-            except IndexError:
-                # There are a few cases of qualifiers without values such as parameter. These are not currently being handled
-                continue
-
+        # There are multiple type qualifiers that change the way we generate a variable
+        # For example, we need to determine if we are creating an array (dimension) or a single variable
+        type_qualifiers = get_children_by_types(node, ["type_qualifier"])
+        for qualifier in type_qualifiers:
+            field = get_identifier(qualifier.children[0], self.source)
+    
             if qualifier == "dimension":
                 intrinsic_type = "List"
             elif qualifier == "intent":
-                variable_intent = value
+                variable_intent = get_identifier(qualifier.children[1], self.source)
 
-        # You can declare multiple variables of the same type in a single statement, so we need to create a Var node for each instance
+
+        # You can declare multiple variables of the same type in a single statement, so we need to create a Var or Assignment node for each instance
+        definied_variables = get_children_by_types(node, [
+            "identifier", # Variable declaration 
+            "assignment_statement", #Variable assignment
+            "call_expression" # Dimension without intent
+            ])
         vars = []
-        for identifier in identifiers:
-            cast_var = self.visit(identifier)
-            cast_var.type = intrinsic_type
-            self.variable_context.update_type(cast_var.val.name, intrinsic_type)
+        for variable in definied_variables:
+            if variable.type == "assignment_statement":
+                if variable.children[0].type == "call_expression":
+                    vars.append(Assignment(
+                        left=self.visit(get_first_child_by_type(variable.children[0], "identifier")),
+                        right=self.visit(variable.children[2]),
+                        source_refs=[get_source_ref(variable, self.source_file_name)]
+                    ))
+                    vars[-1].left.type="dimension"
+                    self.variable_context.update_type(vars[-1].left.val.name, "dimension")
+                else:
+                    # If its a regular assignment, we can update the type normally
+                    vars.append(self.visit(variable)) 
+                    vars[-1].left.type = intrinsic_type
+                    self.variable_context.update_type(vars[-1].left.val.name, intrinsic_type)
 
-            vars.append(cast_var)
-
-        for assignment_statement in assignment_statements:
-            cast_assignment = self.visit(assignment_statement)
-            cast_assignment.left.type = intrinsic_type
-            self.variable_context.update_type(
-                cast_assignment.left.val.name, intrinsic_type
-            )
-
-            vars.append(cast_assignment)
-
-        # If the intent is out, we need to add all these variables to the return values
-        # TODO: But what if one branch has a different return value? Are ifs going to be a seperate context
+            elif variable.type == "identifier":
+                # A basic variable declaration, we visit the identifier and then update the type
+                vars.append(self.visit(variable))
+                vars[-1].type = intrinsic_type
+                self.variable_context.update_type(vars[-1].val.name, intrinsic_type)
+            elif variable.type == "call_expression":
+                # Declaring a dimension variable using the x(1:5) format. It will look like a call expression in tree-sitter.
+                # We treat it like an identifier by visiting its identifier node. Then the type gets overridden by "dimension"
+                vars.append(self.visit(get_first_child_by_type(variable, "identifier")))
+                vars[-1].type = "dimension"
+                self.variable_context.update_type(vars[-1].val.name, "dimension")
+                  
+        # By default, all variables are added to a function's list of return values
+        # If the intent is actually in, then we need to remove them from the list
         if variable_intent == "in":
             for var in vars:
                 self.variable_context.remove_return_value(var.val.name)
@@ -705,23 +720,25 @@ class TS2CAST(object):
         # The extent specifier is the same as a slice, it can have a start, stop, and step
         # We can determine these by looking at the number of control characters in this node.
         # Fortran uses the character ':' to differentiate these values
-        cast_call = Call()
-        cast_call.source_refs = node["source_refs"]
-        cast_call.func = self.get_gromet_function_node("slice")
-        cast_call.arguments = [
+        argument_pointer = 0
+        arguments = [
             LiteralValue("None", "None"),
             LiteralValue("None", "None"),
             LiteralValue("None", "None"),
         ]
-        argument_pointer = 0
-
-        for child in node["original_children_order"]:
-            if child["type"] == ":":
+        for child in node.children:
+            if child.type == ":":
                 argument_pointer += 1
             else:
-                cast_call.arguments[argument_pointer] = self.visit(child)
+                arguments[argument_pointer] = self.visit(child)
 
-        return cast_call
+        return Call(
+            func=self.get_gromet_function_node("slice"),
+            source_language="Fortran",
+            source_language_version="Fortran95",
+            arguments=arguments,
+            source_refs=[get_source_ref(node,self.source_file_name)]
+        )
 
     # NOTE: This function starts with _ because it will never be dispatched to directly. There is not a get node in the tree-sitter parse tree.
     # From context, we will determine when we are accessing an element of a List, and call this function,
@@ -731,41 +748,38 @@ class TS2CAST(object):
         #  (identifier)
         #  (argument_list)
 
-        assert len(node["children"]) == 2
-        identifier = node["children"][0]
-        arguments = node["children"][1]["children"]
+        identifier_node = node.children[0]
+        argument_nodes = get_non_control_children(node.children[1])
 
-        # This is a call to the get Gromet function
-        cast_call = Call()
-        cast_call.source_refs = node["source_refs"]
-
-        # We can generate/get the name node for the "get" function by passing the identifier node to the name visitor
-        cast_call.func = self.get_gromet_function_node("get")
 
         # First argument to get is the List itself. We can get this by passing the identifier to the identifier visitor
-        cast_call.arguments = []
-        cast_call.arguments.append(self.visit(identifier))
+        arguments = []
+        arguments.append(self.visit(identifier_node))
 
         # If there are more than one arguments, then this is a multi dimensional array and we need to use an extended slice
-        if len(arguments) > 1:
+        if len(argument_nodes) > 1:
             dimension_list = LiteralValue()
-            dimension_list.source_refs = node["children"][1]["source_refs"]
             dimension_list.value_type = "List"
             dimension_list.value = []
-            for argument in arguments:
+            for argument in argument_nodes:
                 dimension_list.value.append(self.visit(argument))
 
             extslice_call = Call()
-            extslice_call.source_refs = node["source_refs"]
             extslice_call.func = self.get_gromet_function_node("ext_slice")
             extslice_call.arguments = []
             extslice_call.arguments.append(dimension_list)
 
-            cast_call.arguments.append(extslice_call)
+            arguments.append(extslice_call)
         else:
-            cast_call.arguments.append(self.visit(arguments[0]))
+            arguments.append(self.visit(argument_nodes[0]))
 
-        return cast_call
+        return Call(
+            func=self.get_gromet_function_node("get"),
+            source_language="Fortran",
+            source_language_version="Fortran95",
+            arguments=arguments,
+            source_refs=[get_source_ref(node, self.source_file_name)]
+        )
 
     def _visit_set(self, node):
         # Node structure
@@ -773,39 +787,28 @@ class TS2CAST(object):
         #  (call_expression)
         #  (right side)
 
-        assert (len(node["children"])) == 2
-        left, right = node["children"]
+        left, _, right = node.children
 
         # The left side is equivilent to a call gromet "get", so we will first pass the left side to the get visitor
         # Then we can easily convert this to a "set" call by modifying the fields and then appending the right side to the function arguments
         cast_call = self._visit_get(left)
-        cast_call.source_refs = node["source_refs"]
         cast_call.func = self.get_gromet_function_node("set")
         cast_call.arguments.append(self.visit(right))
 
         return cast_call
 
     def _visit_passthrough(self, node):
-        if len(node["children"]) == 0:
+        if len(node.children) == 0:
             return []
 
-        return self.visit(node["children"][0])
+        return self.visit(node.children[0])
 
     def get_gromet_function_node(self, func_name: str) -> Name:
-        node_dict = {"identifier": func_name, "source_refs": [], "children": []}
-        cast_name = self.visit_name(node_dict)
+        # Idealy, we would be able to create a dummy node and just call the name visitor.
+        # However, tree-sitter does not allow you to create or modify nodes, so we have to recreate the logic here.
+        if self.variable_context.is_variable(func_name):
+            return self.variable_context.get_node(func_name)
 
-        return cast_name
-
-    @staticmethod
-    def update_field(field: Any, element: Any) -> List:
-        if not field:
-            field = []
-
-        if element:
-            if isinstance(element, List):
-                field.extend(element)
-            else:
-                field.append(element)
-
-        return field
+        return self.variable_context.add_variable(
+            func_name, "function", None
+        )

--- a/skema/program_analysis/TS2CAST/util.py
+++ b/skema/program_analysis/TS2CAST/util.py
@@ -2,7 +2,7 @@ from typing import List
 from skema.program_analysis.CAST2FN.model.cast import AstNode, LiteralValue, SourceRef
 
 
-def generate_dummy_source_refs(node: AstNode) -> None:
+def generate_dummy_source_refs(node: AstNode) -> AstNode:
     """Walks a tree of AstNodes replacing any null SourceRefs with a dummy value"""
     if isinstance(node, LiteralValue) and not node.source_code_data_type:
         node.source_code_data_type = ["Fortran", "Fotran95", "None"]
@@ -18,17 +18,5 @@ def generate_dummy_source_refs(node: AstNode) -> None:
                 if isinstance(element, AstNode):
                     generate_dummy_source_refs(element)
 
+    return node
 
-def preprocess(source_code: str) -> str:
-    """
-    Preprocesses Fortran source code:
-    1. Replaces the first occurrence of '|' with '&' if it is the first non-whitespace character in the line.
-    2. Adds an additional '&' to the previous line
-    """
-    processed_lines = []
-    for i, line in enumerate(source_code.splitlines()):
-        if line.lstrip().startswith("|"):
-            line = line.replace("|", "&", 1)
-            processed_lines[-1] += "&"
-        processed_lines.append(line)
-    return "\n".join(processed_lines)

--- a/skema/program_analysis/TS2CAST/variable_context.py
+++ b/skema/program_analysis/TS2CAST/variable_context.py
@@ -1,9 +1,8 @@
-from typing import List, Dict
+from typing import List, Dict, Set
 from skema.program_analysis.CAST2FN.model.cast import (
     Var,
     Name,
 )
-
 
 class VariableContext(object):
     def __init__(self):
@@ -16,6 +15,9 @@ class VariableContext(object):
         # This gives each symbol a unqique name. For example "a" would become "type_name.a"
         # For nested type definitions (derived type in a module), multiple prefixes can be added.
         self.prefix = []
+
+        # Flag neccessary to declare if a function is internal or external
+        self.internal = False
 
         self.variable_id = 0
         self.iterator_id = 0
@@ -100,3 +102,10 @@ class VariableContext(object):
     def exit_record_definition(self):
         """Exit a record definition. Resets the prefix to the empty string"""
         self.prefix.pop()
+
+    def set_internal(self):
+        '''Set the internal flag, meaning, all '''
+        self.internal = True
+
+    def unset_internal(self):
+        self.internal = False

--- a/skema/program_analysis/TS2CAST/variable_context.py
+++ b/skema/program_analysis/TS2CAST/variable_context.py
@@ -7,18 +7,27 @@ from skema.program_analysis.CAST2FN.model.cast import (
 
 class VariableContext(object):
     def __init__(self):
-        self.variable_id = 0
-        self.iterator_id = 0
-        self.stop_condition_id = 0
         self.context = [{}]  # Stack of context dictionaries
         self.context_return_values = [set()]  # Stack of context return values
         self.all_symbols = {}
+        self.record_definitions = {}
+
+        # The prefix is used to handle adding Record types to the variable context.
+        # This gives each symbol a unqique name. For example "a" would become "type_name.a"
+        # For nested type definitions (derived type in a module), multiple prefixes can be added.
+        self.prefix = []
+
+        self.variable_id = 0
+        self.iterator_id = 0
+        self.stop_condition_id = 0
 
     def push_context(self):
+        """Create a new variable context and add it to the stack"""
         self.context.append({})
         self.context_return_values.append(set())
 
     def pop_context(self):
+        """Pop the current variable context off of the stack and remove any references to those symbols."""
         context = self.context.pop()
 
         # Remove symbols from all_symbols variable
@@ -28,6 +37,10 @@ class VariableContext(object):
         self.context_return_values.pop()
 
     def add_variable(self, symbol: str, type: str, source_refs: List) -> Name:
+        """Add a variable to the current variable context"""
+        # Generate the full symbol name using the prefix
+        full_symbol_name = ".".join(self.prefix + [symbol])
+
         cast_name = Name(source_refs=source_refs)
         cast_name.name = symbol
         cast_name.id = self.variable_id
@@ -36,17 +49,18 @@ class VariableContext(object):
         self.variable_id += 1
 
         # Add the node to the variable context
-        self.context[-1][symbol] = {
+        self.context[-1][full_symbol_name] = {
             "node": cast_name,
             "type": type,
         }
 
         # Add reference to all_symbols
-        self.all_symbols[symbol] = self.context[-1][symbol]
+        self.all_symbols[full_symbol_name] = self.context[-1][full_symbol_name]
 
         return cast_name
 
     def is_variable(self, symbol: str) -> bool:
+        """Check if a symbol exists in any context"""
         return symbol in self.all_symbols
 
     def get_node(self, symbol: str) -> Dict:
@@ -56,7 +70,10 @@ class VariableContext(object):
         return self.all_symbols[symbol]["type"]
 
     def update_type(self, symbol: str, type: str):
-        self.all_symbols[symbol]["type"] = type
+        """Update the type associated with a given symbol"""
+        # Generate the full symbol name using the prefix
+        full_symbol_name = ".".join(self.prefix + [symbol])
+        self.all_symbols[full_symbol_name]["type"] = type
 
     def add_return_value(self, symbol):
         self.context_return_values[-1].add(symbol)
@@ -75,3 +92,11 @@ class VariableContext(object):
         self.stop_condition_id += 1
 
         return self.add_variable(symbol, "boolean", None)
+
+    def enter_record_definition(self, name: str):
+        """Enter a record definition. Updates the prefix to the name of the record"""
+        self.prefix.append(name)
+
+    def exit_record_definition(self):
+        """Exit a record definition. Resets the prefix to the empty string"""
+        self.prefix.pop()

--- a/skema/program_analysis/TS2CAST/variable_context.py
+++ b/skema/program_analysis/TS2CAST/variable_context.py
@@ -25,11 +25,22 @@ class VariableContext(object):
 
     def push_context(self):
         """Create a new variable context and add it to the stack"""
+        
+        # TODO: Could this add unwanted variables to the context or overwrite existing variables
+        # If the internal flag is set, then all new scopes will use the top-level context
+        if self.internal:
+            return None
+
         self.context.append({})
         self.context_return_values.append(set())
 
     def pop_context(self):
         """Pop the current variable context off of the stack and remove any references to those symbols."""
+        
+        # If the internal flag is set, then all new scopes will use the top-level context
+        if self.internal:
+            return None
+        
         context = self.context.pop()
 
         # Remove symbols from all_symbols variable

--- a/skema/program_analysis/multi_file_ingester.py
+++ b/skema/program_analysis/multi_file_ingester.py
@@ -1,8 +1,8 @@
 import argparse
 import glob
-
 import sys
 import os.path
+from typing import List
 
 from skema.gromet import GROMET_VERSION
 from skema.gromet.fn import (
@@ -64,46 +64,55 @@ def process_file_system(
             else:
                 print(f"File extension not supported for {full_file}")
             
-            cur_dir = os.getcwd()
-            os.chdir(os.path.join(os.getcwd(), path))
-            generated_gromet = ann_cast_pipeline(
-                cast, gromet=True, to_file=False, from_obj=True
-            )
-            os.chdir(cur_dir)
+            # The Fortran CAST inteface (TS2CAST) can produce multiple CAST modules.
+            # However, the Python interface (python2cast) will only return a single module.
+            # This workaround will normalize a single CAST module into a list for consistent processing.
+            if isinstance(cast, List):
+                cast_list = cast
+            else:
+                cast_list = [cast]
 
-            # Then, after we generate the GroMEt we store it in the 'modules' field
-            # and store its path in the 'module_index' field
-            module_collection.modules.append(generated_gromet)
-
-            # DONE: Change this so that it's the dotted path from the root
-            # i.e. like model.view.sir" like it shows up in Python
-            source_directory = os.path.basename(
-                os.path.normpath(root_dir)
-            )  # We just need the last directory of the path, not the complete path
-            os_module_path = os.path.join(source_directory, f)
-                       
-            # Normalize the path across os and then convert to module dot notation
-            python_module_path = ".".join(os.path.normpath(os_module_path).split(os.path.sep))
-            python_module_path = python_module_path.replace(".py", "").strip()
-            
-            module_collection.module_index.append(python_module_path)
-
-            # Done: Determine how we know a gromet goes in the 'executable' field
-            # We do this by finding all user_defined top level functions in the Gromet
-            # and check if the name 'main' is among them
-            function_networks = [
-                fn
-                for fn in generated_gromet.fn_array
-            ]
-            defined_functions = [
-                fn.b[0].name
-                for fn in function_networks
-                if fn.b[0].function_type == "FUNCTION"
-            ]
-            if "main" in defined_functions:
-                module_collection.executables.append(
-                    len(module_collection.module_index)
+            for cast_module in cast_list:
+                cur_dir = os.getcwd()
+                os.chdir(os.path.join(os.getcwd(), path))
+                generated_gromet = ann_cast_pipeline(
+                    cast_module, gromet=True, to_file=False, from_obj=True
                 )
+                os.chdir(cur_dir)
+
+                # Then, after we generate the GroMEt we store it in the 'modules' field
+                # and store its path in the 'module_index' field
+                module_collection.modules.append(generated_gromet)
+
+                # DONE: Change this so that it's the dotted path from the root
+                # i.e. like model.view.sir" like it shows up in Python
+                source_directory = os.path.basename(
+                    os.path.normpath(root_dir)
+                )  # We just need the last directory of the path, not the complete path
+                os_module_path = os.path.join(source_directory, f)
+                        
+                # Normalize the path across os and then convert to module dot notation
+                python_module_path = ".".join(os.path.normpath(os_module_path).split(os.path.sep))
+                python_module_path = python_module_path.replace(".py", "").strip()
+                
+                module_collection.module_index.append(python_module_path)
+
+                # Done: Determine how we know a gromet goes in the 'executable' field
+                # We do this by finding all user_defined top level functions in the Gromet
+                # and check if the name 'main' is among them
+                function_networks = [
+                    fn
+                    for fn in generated_gromet.fn_array
+                ]
+                defined_functions = [
+                    fn.b[0].name
+                    for fn in function_networks
+                    if fn.b[0].function_type == "FUNCTION"
+                ]
+                if "main" in defined_functions:
+                    module_collection.executables.append(
+                        len(module_collection.module_index)
+                    )
 
         except ImportError as e:
             print("FAILURE")


### PR DESCRIPTION
### **Refactoring pipeline to work directly on tree-sitter nodes:**
Previously,  we were generating our own Dict tree based off of the tree-sitter parse tree. This allowed us to make a few quality of life optimizations such as removing nodes representing control characters like '+' and '=='. 
  
The code has now been refactored to remove this step. This change decreases processing time and will make it easier to support other tree-sitter languages in the future. 

In its place, multiple helper functions have been defined in node_helper.py to better support working with tree-sitter Node objects.

### **Moving tree-sitter parsing out of preprocessor:** 
The tree-sitter parsing of the Fortran source code has been moved out of the preprocessor and into ts2cast.py. Overall, it makes more sense for the preprocessor to return source code rather than a parse tree.

### **Adds supports for Record Idiom:**
We are now support generating CAST for the Record idiom in Fortran. Specifically, the record idiom shows up as a Derived Type.
``` Fortran
type, public :: Circle
   real :: radius
contains
   procedure :: area => circle_area
   procedure :: print => circle_print
end type Circle
```

### **Adds support for multi-module CAST output:**
Previously, there was a 1->1 relationship between source file and CAST module. However, with the addition of the Record idioms, the following are now being processed as their own CAST module:

- Module body
- Program body
- Functions defined outside of module/program

The source->Gromet frontends have also been updated to support this change.

