### PR TITLE
[rest] - Fixing snippets-to-pn-amr and repo-to-pn-amr

### DIFF
--- a/skema/rest/workflows.py
+++ b/skema/rest/workflows.py
@@ -116,24 +116,25 @@ async def equations_to_amr(data: schema.MmlToAMR):
 @router.post("/code/snippets-to-pn-amr", summary="Code snippets → PetriNet AMR")
 async def code_snippets_to_pn_amr(system: code2fn.System):
     gromet = await code2fn.fn_given_filepaths(system)
-    res = requests.post(f"{SKEMA_RS_ADDESS}/models/PN", json=gromet)
+    res = requests.put(f"{SKEMA_RS_ADDESS}/models/PN", json=gromet)
     if res.status_code != 200:
         return JSONResponse(
             status_code=400,
             content={
-                "error": f"MORAE POST /models/PN failed to process payload",
+                "error": f"MORAE PUT /models/PN failed to process payload",
                 "payload": gromet,
             },
         )
     return res.json()
 
-
+''' TODO: The regnet endpoints are currently outdated
 # code snippets -> fn -> regnet amr
 @router.post("/code/snippets-to-rn-amr", summary="Code snippets → RegNet AMR")
 async def code_snippets_to_rn_amr(system: code2fn.System):
     gromet = await code2fn.fn_given_filepaths(system)
-    res = requests.post(f"{SKEMA_RS_ADDESS}/models/RN", json=gromet)
+    res = requests.put(f"{SKEMA_RS_ADDESS}/models/RN", json=gromet)
     if res.status_code != 200:
+        print(res.status_code)
         return JSONResponse(
             status_code=400,
             content={
@@ -142,7 +143,7 @@ async def code_snippets_to_rn_amr(system: code2fn.System):
             },
         )
     return res.json()
-
+'''
 
 # zip archive -> fn -> petrinet amr
 @router.post(
@@ -150,23 +151,23 @@ async def code_snippets_to_rn_amr(system: code2fn.System):
 )
 async def repo_to_pn_amr(zip_file: UploadFile = File()):
     gromet = await code2fn.fn_given_filepaths_zip(zip_file)
-    res = requests.post(f"{SKEMA_RS_ADDESS}/models/PN", json=gromet)
+    res = requests.put(f"{SKEMA_RS_ADDESS}/models/PN", json=gromet)
     if res.status_code != 200:
         return JSONResponse(
             status_code=400,
             content={
-                "error": f"MORAE POST /models/PN failed to process payload",
+                "error": f"MORAE PUT /models/PN failed to process payload",
                 "payload": gromet,
             },
         )
     return res.json()
 
-
+''' TODO: The regnet endpoints are currently outdated
 # zip archive -> fn -> regnet amr
 @router.post("/code/codebase-to-rn-amr", summary="Code repo (zip archive) → RegNet AMR")
 async def repo_to_rn_amr(zip_file: UploadFile = File()):
     gromet = await code2fn.fn_given_filepaths_zip(zip_file)
-    res = requests.post(f"{SKEMA_RS_ADDESS}/models/RN", json=gromet)
+    res = requests.put(f"{SKEMA_RS_ADDESS}/models/RN", json=gromet)
     if res.status_code != 200:
         return JSONResponse(
             status_code=400,
@@ -176,3 +177,4 @@ async def repo_to_rn_amr(zip_file: UploadFile = File()):
             },
         )
     return res.json()
+'''

--- a/skema/rest/workflows.py
+++ b/skema/rest/workflows.py
@@ -81,8 +81,7 @@ async def equations_to_amr(data: schema.EquationLatexToAMR):
     r.json()
     """
     mml: List[str] = [
-        utils.clean_mml(eqn2mml.get_mathml_from_latex(tex))
-        for tex in data.equations
+        utils.clean_mml(eqn2mml.get_mathml_from_latex(tex)) for tex in data.equations
     ]
     payload = {"mathml": mml, "model": data.model}
     res = requests.put(f"{SKEMA_RS_ADDESS}/mathml/amr", json=payload)
@@ -95,6 +94,7 @@ async def equations_to_amr(data: schema.EquationLatexToAMR):
             },
         )
     return res.json()
+
 
 # pmml -> amr
 @router.post("/pmml/equations-to-amr", summary="Equations pMML → AMR")
@@ -112,6 +112,7 @@ async def equations_to_amr(data: schema.MmlToAMR):
         )
     return res.json()
 
+
 # code snippets -> fn -> petrinet amr
 @router.post("/code/snippets-to-pn-amr", summary="Code snippets → PetriNet AMR")
 async def code_snippets_to_pn_amr(system: code2fn.System):
@@ -127,7 +128,8 @@ async def code_snippets_to_pn_amr(system: code2fn.System):
         )
     return res.json()
 
-''' TODO: The regnet endpoints are currently outdated
+
+""" TODO: The regnet endpoints are currently outdated
 # code snippets -> fn -> regnet amr
 @router.post("/code/snippets-to-rn-amr", summary="Code snippets → RegNet AMR")
 async def code_snippets_to_rn_amr(system: code2fn.System):
@@ -143,7 +145,7 @@ async def code_snippets_to_rn_amr(system: code2fn.System):
             },
         )
     return res.json()
-'''
+"""
 
 # zip archive -> fn -> petrinet amr
 @router.post(
@@ -162,7 +164,8 @@ async def repo_to_pn_amr(zip_file: UploadFile = File()):
         )
     return res.json()
 
-''' TODO: The regnet endpoints are currently outdated
+
+""" TODO: The regnet endpoints are currently outdated
 # zip archive -> fn -> regnet amr
 @router.post("/code/codebase-to-rn-amr", summary="Code repo (zip archive) → RegNet AMR")
 async def repo_to_rn_amr(zip_file: UploadFile = File()):
@@ -177,4 +180,4 @@ async def repo_to_rn_amr(zip_file: UploadFile = File()):
             },
         )
     return res.json()
-'''
+"""


### PR DESCRIPTION
There was a bug in the amr workflows caused by using the wrong http request method when communicating with the skema-rs services. This has been fixed by switching these requests from POST to PUT.

Additionally, the regnet endpoints `code_snippets_to_rn_amr` and `repo_to_rn_amr` have been temporarily disabled because they are outdated.