### PR TITLE
Skema-rs version tracking

### DIFF
--- a/skema/skema-rs/skema/src/bin/skema_service.rs
+++ b/skema/skema-rs/skema/src/bin/skema_service.rs
@@ -32,6 +32,19 @@ pub async fn ping() -> HttpResponse {
     HttpResponse::Ok().body("The SKEMA Rust web services are running.")
 }
 
+
+/// This endpoint can be used to check the version of the service.
+#[utoipa::path(
+    responses(
+        (status = 200, description = "Version")
+    )
+)]
+#[get("/version")]
+pub async fn version() -> HttpResponse {
+    let end_version = env::var("APP_VERSION").unwrap_or("?????".to_string());
+    HttpResponse::Ok().body(end_version)
+}
+
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     pretty_env_logger::init();
@@ -62,7 +75,8 @@ async fn main() -> std::io::Result<()> {
             gromet::get_model_RN,
             gromet::model2PN,
             gromet::model2RN,
-            ping
+            ping,
+            version
         ),
         components(
             schemas(
@@ -118,10 +132,10 @@ async fn main() -> std::io::Result<()> {
     )]
     struct ApiDoc;
 
-    let version = env::var("APP_VERSION").unwrap_or("?????".to_string());
+    let version_hash = env::var("APP_VERSION").unwrap_or("?????".to_string());
 
     let mut openapi = ApiDoc::openapi();
-    openapi.info.version = version.to_string();
+    openapi.info.version = version_hash.to_string();
     let args = Cli::parse();
 
     HttpServer::new(move || {
@@ -143,6 +157,7 @@ async fn main() -> std::io::Result<()> {
             .service(gromet::model2PN)
             .service(gromet::model2RN)
             .service(ping)
+            .service(version)
             .service(SwaggerUi::new("/docs/{_:.*}").url("/api-doc/openapi.json", openapi.clone()))
     })
     .bind((args.host, args.port))?

--- a/skema/skema-rs/skema/src/bin/skema_service.rs
+++ b/skema/skema-rs/skema/src/bin/skema_service.rs
@@ -1,7 +1,7 @@
 use actix_web::{get, web::Data, App, HttpResponse, HttpServer};
 use skema::config::Config;
 use skema::services::{comment_extraction, gromet};
-
+use std::env;
 use clap::Parser;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
@@ -34,10 +34,18 @@ pub async fn ping() -> HttpResponse {
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+
+    let version = env::var("APP_VERSION").unwrap();
+    let version_slice = &version[0..6];
+
     pretty_env_logger::init();
 
     #[derive(OpenApi)]
     #[openapi(
+        info(
+            title = "SKEMA RUST SERVICES",
+            version = version_slice,
+        ),
         paths(
             comment_extraction::get_comments,
             comment_extraction::get_comments_from_zipfile,

--- a/skema/skema-rs/skema/src/bin/skema_service.rs
+++ b/skema/skema-rs/skema/src/bin/skema_service.rs
@@ -34,17 +34,13 @@ pub async fn ping() -> HttpResponse {
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-
-    let version = env::var("APP_VERSION").unwrap();
-    let version_slice = &version[0..6];
-
     pretty_env_logger::init();
 
     #[derive(OpenApi)]
     #[openapi(
         info(
             title = "SKEMA RUST SERVICES",
-            version = version_slice,
+            version = "version",
         ),
         paths(
             comment_extraction::get_comments,
@@ -122,8 +118,10 @@ async fn main() -> std::io::Result<()> {
     )]
     struct ApiDoc;
 
-    let openapi = ApiDoc::openapi();
+    let version = env::var("APP_VERSION").unwrap_or("?????".to_string());
 
+    let mut openapi = ApiDoc::openapi();
+    openapi.info.version = version.to_string();
     let args = Cli::parse();
 
     HttpServer::new(move || {


### PR DESCRIPTION
This adds version tracking from and environment variable named: APP_VERSION
If no variable is given it defaults to ?????

This will setup the version as the openapi docs version and there is a new endpoint that pulls the version. 

(Gus I think you need to add stuff to the docker compose files still for this?)