### PR TITLE
response type for GET /version should be plaintext

### DIFF
--- a/skema/rest/api.py
+++ b/skema/rest/api.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, Response, status
+from fastapi.responses import PlainTextResponse
 import os
 from skema.rest import (
     schema,
@@ -124,7 +125,7 @@ app.include_router(
 
 @app.get("/version", tags=["core"], summary="API version")
 async def version() -> str:
-    return VERSION
+    return PlainTextResponse(VERSION)
 
 
 @app.get(

--- a/skema/skema-rs/skema/src/bin/skema_service.rs
+++ b/skema/skema-rs/skema/src/bin/skema_service.rs
@@ -1,4 +1,4 @@
-use actix_web::{get, web::Data, App, HttpResponse, HttpServer};
+use actix_web::{get, web::Data, App, http::header::ContentType, HttpResponse, HttpServer};
 use skema::config::Config;
 use skema::services::{comment_extraction, gromet};
 use std::env;
@@ -42,7 +42,7 @@ pub async fn ping() -> HttpResponse {
 #[get("/version")]
 pub async fn version() -> HttpResponse {
     let end_version = env::var("APP_VERSION").unwrap_or("?????".to_string());
-    HttpResponse::Ok().body(end_version)
+    HttpResponse::Ok().content_type(ContentType::plaintext()).body(end_version)
 }
 
 #[actix_web::main]


### PR DESCRIPTION
This PR ensures the response type for /version is set to plaintext.