### PR TITLE
Improved Error Handling mathml/amr, mathml/petrinet and mathml/ast-graph endpoints

### DIFF
--- a/skema/skema-rs/mathml/src/parsers/first_order_ode.rs
+++ b/skema/skema-rs/mathml/src/parsers/first_order_ode.rs
@@ -99,13 +99,16 @@ impl FirstOrderODE {
 }
 
 impl FromStr for FirstOrderODE {
-    type Err = Error<String>;
+    type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let ode = first_order_ode(s.into()).unwrap().1;
-        Ok(ode)
+        first_order_ode(s.into())
+            .map(|(_, ode)| ode)
+            .map_err(|err| err.to_string())
     }
 }
+
+
 
 //--------------------------------------
 // Methods for extraction of PN AMR from ODE's

--- a/skema/skema-rs/mathml/src/parsers/first_order_ode.rs
+++ b/skema/skema-rs/mathml/src/parsers/first_order_ode.rs
@@ -108,8 +108,6 @@ impl FromStr for FirstOrderODE {
     }
 }
 
-
-
 //--------------------------------------
 // Methods for extraction of PN AMR from ODE's
 //--------------------------------------

--- a/skema/skema-rs/mathml/src/parsers/generic_mathml.rs
+++ b/skema/skema-rs/mathml/src/parsers/generic_mathml.rs
@@ -347,11 +347,12 @@ pub fn parse(input: &str) -> IResult<Math> {
 }
 
 impl FromStr for Math {
-    type Err = Error<String>;
+    type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let (_, math) = math(s.into()).unwrap();
-        Ok(math)
+        math(s.into())
+            .map(|(_, math)| math)
+            .map_err(|err| err.to_string())
     }
 }
 

--- a/skema/skema-rs/skema/src/services/mathml.rs
+++ b/skema/skema-rs/skema/src/services/mathml.rs
@@ -4,7 +4,7 @@ use mathml::{
     acset::{AMRmathml, PetriNet, RegNet},
     ast::Math,
     expression::{preprocess_content, wrap_math},
-    parsers::first_order_ode::FirstOrderODE,
+    parsers::first_order_ode::{FirstOrderODE, first_order_ode},
 };
 use petgraph::dot::{Config, Dot};
 use utoipa;
@@ -136,7 +136,7 @@ pub async fn get_amr(payload: web::Json<AMRmathml>) -> HttpResponse {
     let mt_asts: Result<Vec<_>, _> = payload
         .mathml
         .iter()
-        .map(|x| x.parse::<FirstOrderODE>())
+        .map(|x| first_order_ode(x.as_str().into()))
         .collect();
 
     match mt_asts {
@@ -144,8 +144,8 @@ pub async fn get_amr(payload: web::Json<AMRmathml>) -> HttpResponse {
             let mut flattened_asts = Vec::<FirstOrderODE>::new();
 
             for mut eq in mt_asts {
-                eq.rhs = flatten_mults(eq.rhs.clone());
-                flattened_asts.push(eq.clone());
+                eq.1.rhs = flatten_mults(eq.1.rhs.clone());
+                flattened_asts.push(eq.1.clone());
             }
             let asts: Vec<Math> = payload
                 .mathml

--- a/skema/skema-rs/skema/src/services/mathml.rs
+++ b/skema/skema-rs/skema/src/services/mathml.rs
@@ -1,10 +1,11 @@
 use actix_web::{put, web, HttpResponse};
 use mathml::parsers::first_order_ode::flatten_mults;
+use mathml::parsers::generic_mathml::math;
 use mathml::{
     acset::{AMRmathml, PetriNet, RegNet},
     ast::Math,
     expression::{preprocess_content, wrap_math},
-    parsers::first_order_ode::{FirstOrderODE, first_order_ode},
+    parsers::first_order_ode::{first_order_ode, FirstOrderODE},
 };
 use petgraph::dot::{Config, Dot};
 use utoipa;
@@ -22,9 +23,9 @@ use utoipa;
 #[put("/mathml/ast-graph")]
 pub async fn get_ast_graph(payload: String) -> String {
     let contents = &payload;
-    let math_results = contents.parse::<Math>();
+    let math_results = math(contents.as_str().into());
     match math_results {
-        Ok(math) => {
+        Ok((_, math)) => {
             let g = math.to_graph();
             let dot_representation = Dot::with_config(&g, &[Config::EdgeNoLabel]);
             dot_representation.to_string()
@@ -86,13 +87,15 @@ pub async fn get_content_mathml(payload: String) -> String {
 )]
 #[put("/mathml/petrinet")]
 pub async fn get_acset(payload: web::Json<Vec<String>>) -> HttpResponse {
-    let asts_result: Result<Vec<_>, _> =
-        payload.iter().map(|x| x.parse::<FirstOrderODE>()).collect();
+    let asts_result: Result<Vec<_>, _> = payload
+        .iter()
+        .map(|x| first_order_ode(x.as_str().into()))
+        .collect();
 
     match asts_result {
         Ok(asts) => {
             let mut flattened_asts = Vec::<FirstOrderODE>::new();
-            for mut eq in asts {
+            for (_, mut eq) in asts {
                 eq.rhs = flatten_mults(eq.rhs.clone());
                 flattened_asts.push(eq.clone());
             }
@@ -143,9 +146,9 @@ pub async fn get_amr(payload: web::Json<AMRmathml>) -> HttpResponse {
         Ok(mt_asts) => {
             let mut flattened_asts = Vec::<FirstOrderODE>::new();
 
-            for mut eq in mt_asts {
-                eq.1.rhs = flatten_mults(eq.1.rhs.clone());
-                flattened_asts.push(eq.1.clone());
+            for (_, mut eq) in mt_asts {
+                eq.rhs = flatten_mults(eq.rhs.clone());
+                flattened_asts.push(eq.clone());
             }
             let asts: Vec<Math> = payload
                 .mathml


### PR DESCRIPTION
### Changes
#### Errors generated at endpoints
  - `/mathml/amr` and `/mathml/petrinet`. The following errors have been added
    - MISSING STARTING <math> TAG.
    - INVALID DERIVATIVE ON LHS.
    - MISSING EQUALS SIGN.
    - COULD NOT PARSE RHS.
    - MISSING ENDING </math> tag.
  - `/mathml/ast-graph`. The errors are only the generic `ParseError` generated by nom with no additional specificity. 
    -  Attempts to add specific errors to the generic MathML parser resulted in the errors only catching missing ending math tags even when it was only an intermediate tag that was missing. Adding specificity to `generic_mathml.rs` will require a deeper dive to solve.

#### Updates to ParseError implementation
 - Added a public function called `append_message` to the `ParseError` struct to allow for updating the error message as it is propagated upwards through nom and our own parsers. It only appends messages and never erases the existing error history in the object.
 - Updating the message in the ParseError requires nom's internal map function. To simplify this step of updating, the code for appending has been updated to a new public macro called `append_msg_to_parse_err`

#### Updates to `FromStr` trait implementation for first-order ODE and generic MathML parsers
- Previously, the `FromStr` trait was being used to parse MathML and FirstOrder ODEs from strings at the endpoints; however, now we use the `first_order_ode` and `math` functions. This was done because the `FromStr` trait doesn't allow lifetime declarations and can only pass back generic rust `Err` results containing a String message. The actual ParseError from nom cannot be propagated, which reduces flexibility for downstream applications.
 - The `FromStr` implementations previously did not propagate any errors and panicked instead, which halted program execution. Even though they cannot propagate ParseErrors, they have been updated to pass back regular Errs on failure so that any future users can catch and manipulate the errors as needed.

### Testing
- Passing `cargo test` and `cargo clippy`