### PR TITLE
Create and publish docker image for text reading webapp

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -253,8 +253,8 @@ jobs:
           # short commit hash
           type=sha
     # The TR image is huge.
-    # We need to fee up every last bit of space we can.
-    - name: Free Disk Space
+    # We need to free up every last bit of space we can.
+    - name: Free disk space
       uses: jlumbroso/free-disk-space@v1.2.0
       with:
         android: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,9 +12,31 @@ on:
 
 # builds and publishes docker images for the default branch.
 # images are tagged with short commit hash, latest, and any tags.
+
 jobs:
+  # Determine value for app version
+  app_version: 
+    name: "Determine app version"
+    runs-on: ubuntu-latest
+    outputs:
+      app_version: ${{ steps.app_version.outputs.app_version }}
+      commit: ${{ steps.app_version.outputs.commit }}
+    steps:
+    - name: Set APP_VERSION output
+      id: app_version
+      run: |
+        echo "app_version=${{github.ref_name}}"
+        if [ -z "${app_version}" ]; then
+            app_version=${{github.sha}}
+            echo "app_version=${app_version}"
+        fi
+        echo "app_version=$app_version" >> "$GITHUB_OUTPUT"
+        echo "commit=${{github.sha}}" >> "$GITHUB_OUTPUT"
+        echo "app_version=$app_version"
+        echo "commit=${{github.sha}}"
   python:
     name: "docker image for python components"
+    needs: [app_version]
     runs-on: ubuntu-latest
     steps:
     # Setup docker
@@ -57,6 +79,7 @@ jobs:
       id: tags
       # see https://github.com/docker/metadata-action
       uses: docker/metadata-action@v4
+
       with:
         images: |
           lumai/askem-skema-py
@@ -83,10 +106,12 @@ jobs:
         # references `tags` step in steps for current job
         tags: ${{ steps.tags.outputs.tags }}
         build-args: |
-          APP_VERSION=${{github.sha}}
+          #APP_VERSION=${{needs.app_version.outputs.app_version}}
+          APP_VERSION=${{needs.app_version.outputs.commit}}
 
   rust:
     name: "docker image for rust components"
+    needs: [app_version]
     runs-on: ubuntu-latest
     steps:
     # Setup docker
@@ -153,10 +178,12 @@ jobs:
         # references `tags` step in steps for current job
         tags: ${{ steps.tags.outputs.tags }}
         build-args: |
-          APP_VERSION=${{github.sha}}
+          #APP_VERSION=${{needs.app_version.outputs.app_version}}
+          APP_VERSION=${{needs.app_version.outputs.commit}}
 
   text_reading:
     name: "docker image for text reading component"
+    needs: [app_version]
     runs-on: ubuntu-latest
     steps:
     # Setup docker
@@ -195,7 +222,22 @@ jobs:
     ########################################
     # lumai/askem-skema-text-reading
     ########################################
-    - name: Tags for image
+    - name: Setup JDK (w/ SBT)
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 11
+        # Unfortunately, this will immediately 
+        # blow through the GH Actions cache...
+        #cache: 'sbt'
+    - name: Generate Dockerfile (TR)
+      working-directory: ./skema/text_reading/scala
+      env:
+        #APP_VERSION=${{needs.app_version.outputs.app_version}}
+        APP_VERSION=${{needs.app_version.outputs.commit}}
+      run: |
+        sbt "webapp/docker:stage"
+    - name: Tags for image (TR)
       id: tags
       # see https://github.com/docker/metadata-action
       uses: docker/metadata-action@v4
@@ -210,12 +252,12 @@ jobs:
           type=ref,event=tag
           # short commit hash
           type=sha
-
-    - name: Build and push image
+    - name: Build and push image (TR)
       # see https://github.com/docker/build-push-action
       uses: docker/build-push-action@v4
       with:
-        context: ./skema/text_reading/scala
+        context: ./skema/text_reading/scala/webapp/target/docker/stage
+        # NOTE: dynet throws an UnsatisfiedLinkError on ARM64 even with a platform compatible JRE.. :(
         platforms: linux/amd64
         push: ${{ github.event_name != 'pull_request' }}
         # references `tags` step in steps for current job

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -252,6 +252,18 @@ jobs:
           type=ref,event=tag
           # short commit hash
           type=sha
+    # The TR image is huge.
+    # We need to fee up every last bit of space we can.
+    - name: Free Disk Space
+      uses: jlumbroso/free-disk-space@v1.2.0
+      with:
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: true
+        swap-storage: true
+        tool-cache: false
     - name: Build and push image (TR)
       # see https://github.com/docker/build-push-action
       uses: docker/build-push-action@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -233,8 +233,8 @@ jobs:
     - name: Generate Dockerfile (TR)
       working-directory: ./skema/text_reading/scala
       env:
-        #APP_VERSION=${{needs.app_version.outputs.app_version}}
-        APP_VERSION=${{needs.app_version.outputs.commit}}
+        #APP_VERSION: ${{needs.app_version.outputs.app_version}}
+        APP_VERSION: ${{needs.app_version.outputs.commit}}
       run: |
         sbt "webapp/docker:stage"
     - name: Tags for image (TR)

--- a/skema/text_reading/scala/webapp/app/controllers/HomeController.scala
+++ b/skema/text_reading/scala/webapp/app/controllers/HomeController.scala
@@ -1,5 +1,7 @@
 package controllers
 
+import ai.lum.common.ConfigUtils._
+import com.typesafe.config.{Config, ConfigFactory}
 import org.clulab.odin.{EventMention, Mention, RelationMention, TextBoundMention}
 import org.clulab.pdf2txt.document.logical.DocumentByWord
 import org.clulab.processors.{Document, Sentence}
@@ -51,6 +53,11 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
 
   logger.info("Completed Initialization ...")
 
+
+  // config
+  val config = ConfigFactory.load()
+  val appVersion: String = config[String]("skema.version")
+
   // -----------------------------------------------------------------
   // Home page
   // -----------------------------------------------------------------
@@ -58,6 +65,11 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
   def index() = Action { implicit request: Request[AnyContent] =>
     Ok(views.html.index())
   }
+
+  /**
+   * Returns the App version using the APP_VERSION ENV variable.
+   */
+  def version() = Action { Ok(appVersion) }
 
   def parseSentence(sent: String, showEverything: Boolean) = Action {
     val (doc, eidosMentions) = processPlayText(sent)

--- a/skema/text_reading/scala/webapp/conf/application.conf
+++ b/skema/text_reading/scala/webapp/conf/application.conf
@@ -9,7 +9,7 @@ play.filters.csp.directives {
 }
 
 play.http.secret.key = "changeme"
-play.http.secret.key = ${?secret} // One can override the value with an environment variable.
+play.http.secret.key = ${?APPLICATION_SECRET}
 
 play.filters {
   disabled += "play.filters.csrf.CSRFFilter"

--- a/skema/text_reading/scala/webapp/conf/application.conf
+++ b/skema/text_reading/scala/webapp/conf/application.conf
@@ -19,6 +19,10 @@ play.filters {
 skema.hostname = "skema.clulab.org"
 skema.hostname = ${?SKEMA_HOSTNAME}
 
+
+skema.version = "???"
+skema.version = ${?APP_VERSION}
+
 play.filters.hosts {
   allowed = [ ${skema.hostname}, "." ]
 }

--- a/skema/text_reading/scala/webapp/conf/routes
+++ b/skema/text_reading/scala/webapp/conf/routes
@@ -7,6 +7,9 @@
 GET     /                                  controllers.HomeController.index
 GET     /parseSentence                     controllers.HomeController.parseSentence(sent: String, showEverything: Boolean)
 
+# Utils
+GET    /version                            controllers.HomeController.version
+
 # Provide API functions
 POST    /cosmosJsonToMentions              controllers.HomeController.cosmosJsonToMentions
 # This should be documented in the API

--- a/skema/text_reading/scala/webapp/docker.sbt
+++ b/skema/text_reading/scala/webapp/docker.sbt
@@ -2,7 +2,7 @@ import NativePackagerHelper._
 import com.typesafe.sbt.packager.MappingsHelper.directory
 import com.typesafe.sbt.packager.docker.{Cmd, CmdLike, DockerChmodType, DockerPermissionStrategy}
 
-val topDir = "/skema/webapp"
+val topDir = "/skema/text_reading/webapp"
 val appDir = topDir + "/app"
 val binDir = appDir + "/bin/" // The second half is determined by the plug-in.  Don't change.
 val app = binDir + "webapp"
@@ -24,7 +24,10 @@ Docker / mappings := (Docker / mappings).value.filter { case (_, string) =>
 Docker / packageName := "skema-webapp"
 Docker / version := tag
 // set our version based on our env variable
-dockerEnvVars ++= Map(("APP_VERSION", scala.util.Properties.envOrElse("APP_VERSION", "???")))
+dockerEnvVars ++= Map(
+  "APP_VERSION" -> scala.util.Properties.envOrElse("APP_VERSION", "???"),
+  "APPLICATION_SECRET" -> "this-is-not-a-secure-key-please-change-me"
+)
 dockerAdditionalPermissions += (DockerChmodType.UserGroupPlusExecute, app)
 dockerChmodType := DockerChmodType.UserGroupWriteExecute
 // dockerCmd := Seq(s"-Dhttp.port=$port")

--- a/skema/text_reading/scala/webapp/docker.sbt
+++ b/skema/text_reading/scala/webapp/docker.sbt
@@ -9,8 +9,10 @@ val app = binDir + "webapp"
 val port = 9000
 val tag = "1.0.0"
 
+
 Docker / defaultLinuxInstallLocation := appDir
-Docker / dockerBaseImage := "openjdk:8"
+// TODO: can we run this with 11 (i.e., eclipse-temurin:11-jre-focal)?
+Docker / dockerBaseImage := "eclipse-temurin:8-jre-focal"
 Docker / daemonUser := "nobody"
 Docker / dockerExposedPorts := List(port)
 Docker / maintainer := "Keith Alcock <docker@keithalcock.com>"
@@ -21,7 +23,8 @@ Docker / mappings := (Docker / mappings).value.filter { case (_, string) =>
 }
 Docker / packageName := "skema-webapp"
 Docker / version := tag
-
+// set our version based on our env variable
+dockerEnvVars ++= Map(("APP_VERSION", scala.util.Properties.envOrElse("APP_VERSION", "???")))
 dockerAdditionalPermissions += (DockerChmodType.UserGroupPlusExecute, app)
 dockerChmodType := DockerChmodType.UserGroupWriteExecute
 // dockerCmd := Seq(s"-Dhttp.port=$port")


### PR DESCRIPTION
## Summary of changes

- Replaces the building and publishing of a text reading image that packages a CLI runnable in favor of one that packages a webapp exposing REST services.  
- Introduces the `/version` endpoint to the text reading web app (following similar REST endpoints in `skema-py` and `skema-rs`)
- Exposes ENV variable for application secret
- Resolves path problem with runnable (previously `text_reading` was missing)

### Issues resolved
- Resolves #446 
- Resolves #447 
- Resolves #449