### PR TITLE
Unicode support for newtonian derivative

### DIFF
--- a/skema/skema-rs/mathml/src/parsers/first_order_ode.rs
+++ b/skema/skema-rs/mathml/src/parsers/first_order_ode.rs
@@ -1020,3 +1020,24 @@ fn test_first_order_ode() {
     assert_eq!(lhs_var.to_string(), "S");
     assert_eq!(rhs.to_string(), "(/ (* (* (- β) I) S) N)");
 }
+
+#[test]
+fn test_msub_derivative() {
+    test_parser(
+        "<mfrac>
+        <mrow><mi>d</mi><msub><mi>S</mi><mi>v</mi></msub></mrow>
+        <mrow><mi>d</mi><mi>t</mi></mrow>
+        </mfrac>",
+        first_order_derivative_leibniz_notation,
+        (
+            Derivative::new(1, 1),
+            Ci::new(
+                None,
+                Box::new(MathExpression::Msub(
+                    Box::new(MathExpression::Mi(Mi("S".to_string()))),
+                    Box::new(MathExpression::Mi(Mi("v".to_string()))),
+                )),
+            ),
+        ),
+    );
+}

--- a/skema/skema-rs/mathml/src/parsers/first_order_ode.rs
+++ b/skema/skema-rs/mathml/src/parsers/first_order_ode.rs
@@ -1041,3 +1041,18 @@ fn test_msub_derivative() {
         ),
     );
 }
+
+#[test]
+fn test_unicode_newtonian_derivative() {
+    test_parser(
+        "<mover><mi>S</mi><mo>&#x02D9;</mo></mover><mo>(</mo><mi>t</mi><mo>)</mo>",
+        newtonian_derivative,
+        (
+            Derivative::new(1, 1),
+            Ci::new(
+                Some(Type::Function),
+                Box::new(MathExpression::Mi(Mi("S".to_string()))),
+            ),
+        ),
+    );
+}

--- a/skema/skema-rs/mathml/src/parsers/interpreted_mathml.rs
+++ b/skema/skema-rs/mathml/src/parsers/interpreted_mathml.rs
@@ -18,7 +18,7 @@ use crate::{
 use nom::{
     branch::alt,
     bytes::complete::tag,
-    combinator::{map, opt},
+    combinator::{map, opt, value},
     multi::{many0, many1},
     sequence::{delimited, pair, preceded, terminated, tuple},
 };
@@ -105,9 +105,12 @@ pub fn newtonian_derivative(input: Span) -> IResult<(Derivative, Ci)> {
     // Get number of dots to recognize the order of the derivative
     let n_dots = delimited(
         stag!("mo"),
-        map(many1(nom::character::complete::char('˙')), |x| {
-            x.len() as u8
-        }),
+        alt((
+            map(many1(nom::character::complete::char('˙')), |x| {
+                x.len() as u8
+            }),
+            value(1_u8, tag("&#x02D9;")),
+        )),
         etag!("mo"),
     );
 

--- a/skema/skema-rs/mathml/src/parsers/interpreted_mathml.rs
+++ b/skema/skema-rs/mathml/src/parsers/interpreted_mathml.rs
@@ -88,6 +88,7 @@ pub fn first_order_derivative_leibniz_notation(input: Span) -> IResult<(Derivati
             r#type: Some(Type::Function),
             content,
         }),
+        ci_subscript,
     )))(s)?;
     let (s, _) = tuple((
         etag!("mrow"),


### PR DESCRIPTION
Incorporated Unicode support for Newtonian derivative:  

Unicode for `˙` is  `&#x02D9;` in MathML representation for Newtonian derivative. 