### PR TITLE
[fortran] Support for fixed-form source and pinned tree-sitter-parser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,9 +114,7 @@ addopts = "--cov=skema --cov-report html:docs/coverage/python"
 testpaths = [
     "skema/program_analysis/tests",
     "skema/img2mml/tests",
-    "skema/rest/tests",
-    "skema/skema_py/tests",
-    "skema/program_analysis/tree_sitter_parsers/tests"
+    "skema/rest/tests"
 ]
 
 # Configuration for Black.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,10 @@ addopts = "--cov=skema --cov-report html:docs/coverage/python"
 testpaths = [
     "skema/program_analysis/tests",
     "skema/img2mml/tests",
-    "skema/rest/tests"
+    "skema/rest/tests",
+    "skema/skema_py/tests",
+    "skema/program_analysis/tree_sitter_parsers/tests",
+    "skema/program_analysis/comment_extractor/tests"
 ]
 
 # Configuration for Black.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,8 +116,7 @@ testpaths = [
     "skema/img2mml/tests",
     "skema/rest/tests",
     "skema/skema_py/tests",
-    "skema/program_analysis/tree_sitter_parsers/tests",
-    "skema/program_analysis/comment_extractor/tests"
+    "skema/program_analysis/tree_sitter_parsers/tests"
 ]
 
 # Configuration for Black.

--- a/skema/program_analysis/CAST/fortran/preprocessor/fixed2free.py
+++ b/skema/program_analysis/CAST/fortran/preprocessor/fixed2free.py
@@ -1,0 +1,174 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# fixed2free2.py: Conversion of Fortran code from fixed to free
+#                 source form.
+#
+# Copyright (C) 2012    Elias Rabel
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Script that converts fixed form Fortran code to free form
+Usage: file name as first command line parameter
+
+python fixed2free2.py file.f > file.f90
+"""
+
+# author: Elias Rabel, 2012
+# Let me know if you find this script useful:
+# ylikx.0 at gmail
+# https://www.github.com/ylikx/
+
+# TODO:
+# *) Improve command line usage
+
+from __future__ import print_function
+import sys
+
+class FortranLine:
+    def __init__(self, line):
+        self.line = line
+        self.line_conv = line
+        self.isComment = False
+        self.isContinuation = False
+        self.__analyse()
+        
+    def __repr__(self):
+        return self.line_conv
+        
+    def continueLine(self):
+        """Insert line continuation symbol at correct position in a free format line."""
+        if not self.isOMP:
+            before_inline_comment, inline_comment = extract_inline_comment(self.line_conv)
+        else:
+            tmp, inline_comment = extract_inline_comment(self.line_conv[1:].lstrip())
+            before_inline_comment = "!" + tmp
+        
+        if inline_comment == "":
+            self.line_conv = self.line_conv.rstrip() + " &\n"
+        else:
+            len_before = len(before_inline_comment)
+            before = before_inline_comment.rstrip() + " & "
+            self.line_conv = before.ljust(len_before) + inline_comment
+                  
+    def __analyse(self):
+        line = self.line
+        # MODIFICATION: Handle tabs that have been converted to spaces by GCC
+        if line[0] == " " and line[1] != " ":
+            line = "      " + line[1:]
+        
+        firstchar = line[0] if len(line) > 0 else ''
+        self.label = line[0:5].strip().lower() + ' ' if len(line) > 1 else ''
+        cont_char = line[5] if len(line) >= 6 else ''
+        fivechars = line[1:5] if len(line) > 1 else ''
+        self.isShort = (len(line) <= 6)
+        self.isLong  = (len(line) > 73)
+        
+        
+        self.isComment = firstchar in "cC*!"
+        self.isNewComment = '!' in fivechars and not self.isComment
+        self.isOMP = self.isComment and fivechars.lower() == "$omp"
+        if self.isOMP:
+            self.isComment = False
+            self.label = ''
+        self.isCppLine = (firstchar == '#')
+        self.is_regular = (not (self.isComment or self.isNewComment or 
+                           self.isCppLine or self.isShort))      
+        self.isContinuation = (not (cont_char.isspace() or cont_char == '0') and
+                               self.is_regular)
+
+        self.code = line[6:] if len(line) > 6 else '\n'
+
+        self.excess_line = '' 
+        if self.isLong and self.is_regular:
+            code, inline_comment = extract_inline_comment(self.code)
+            if inline_comment == "" or len(code) >= 72 - 6:
+                self.excess_line = line[72:]
+                line = line[:72] + '\n'
+                self.code = line[6:]
+        
+        self.line = line
+        self.__convert()
+
+    def __convert(self):
+        line = self.line
+
+        if self.isComment:
+            self.line_conv = '!' + line[1:]
+        elif self.isNewComment or self.isCppLine:
+            self.line_conv = line
+        elif self.isOMP:
+            self.line_conv = '!' + line[1:5] + ' ' + self.code
+        elif not self.label.isspace():
+            self.line_conv = self.label + self.code
+        else:
+            self.line_conv = self.code
+
+        if self.excess_line != '':
+            if self.excess_line.lstrip().startswith("!"):
+                marker = ""
+            else:
+                marker = "!"
+            
+            self.line_conv = self.line_conv.rstrip().ljust(72) + marker + self.excess_line
+
+def extract_inline_comment(code):
+    """Splits line of code into (code, inline comment)"""
+    stringmode = False
+    stringchar = ""
+    
+    for column, character in enumerate(code):
+        is_string_delimiter = (character == "'" or character == '"')
+        if not stringmode and is_string_delimiter:
+            stringmode = True
+            stringchar = character
+        elif stringmode and is_string_delimiter:
+            stringmode = (character != stringchar)
+        elif not stringmode and character == "!":
+            return code[:column], code[column:]
+            
+    return code, ""
+
+
+def convertToFree(stream):
+    """Convert stream from fixed source form to free source form."""
+    linestack = []
+        
+    for line in stream:
+        convline = FortranLine(line)
+        
+        if convline.is_regular:
+            if convline.isContinuation and linestack: 
+                linestack[0].continueLine()
+            for l in linestack:
+                yield str(l)
+            linestack = []
+            
+        linestack.append(convline)
+        
+    for l in linestack:
+        yield str(l)
+        
+
+if __name__ == "__main__":
+
+    if len(sys.argv) > 1:
+        infile = open(sys.argv[1], 'r')
+        for line in convertToFree(infile):
+            print(line, end="")
+    
+        infile.close()
+    else:
+        print(__doc__)

--- a/skema/program_analysis/CAST/fortran/preprocessor/fixed2free.py
+++ b/skema/program_analysis/CAST/fortran/preprocessor/fixed2free.py
@@ -34,6 +34,9 @@ python fixed2free2.py file.f > file.f90
 # TODO:
 # *) Improve command line usage
 
+# Modifications by vincentraymond-ua
+# Convert tab-form lines that have been changed to a single space by GCC to free-form before processing
+
 from __future__ import print_function
 import sys
 

--- a/skema/program_analysis/CAST/fortran/tests/test_tiegcm.py
+++ b/skema/program_analysis/CAST/fortran/tests/test_tiegcm.py
@@ -54,7 +54,7 @@ def test_parse_tiegcm():
         print(f"original: {parsable}")
         print(f"preprocess: {preprocess_parsable}")
 
-        # assert parsable or preprocess_parsable
+        assert parsable or preprocess_parsable
 
 
 test_parse_tiegcm()

--- a/skema/program_analysis/CAST/fortran/tests/test_tiegcm.py
+++ b/skema/program_analysis/CAST/fortran/tests/test_tiegcm.py
@@ -1,0 +1,60 @@
+import requests
+import zipfile
+import io
+from tempfile import TemporaryFile, TemporaryDirectory
+from pathlib import Path
+
+from tree_sitter import Language, Parser
+
+from skema.program_analysis.tree_sitter_parsers.build_parsers import (
+    INSTALLED_LANGUAGES_FILEPATH,
+)
+from skema.program_analysis.CAST.fortran.preprocessor.preprocess import preprocess
+
+TIE_GCM_URL = (
+    "https://artifacts.askem.lum.ai/askem/data/models/zip-archives/TIE-GCM.zip"
+)
+
+
+def validate_parse_tree(source: str) -> bool:
+    """Parse source with tree-sitter and check if an error is returned."""
+    language = Language(INSTALLED_LANGUAGES_FILEPATH, "fortran")
+    parser = Parser()
+    parser.set_language(language)
+    tree = parser.parse(bytes(source, encoding="utf-8"))
+    return "ERROR" not in tree.root_node.sexp()
+
+
+def test_parse_tiegcm():
+    response = requests.get(TIE_GCM_URL)
+    zip = zipfile.ZipFile(io.BytesIO(response.content))
+
+    # We will run two sets of tests:
+    # 1. Parse with tree-sitter as-is
+    # 2. Parse with tree-sitter after preprocessing
+    for file in zip.filelist:
+        if file.filename.endswith(".py"):
+            continue
+        source = str(zip.open(file).read(), encoding="utf-8")
+        with TemporaryDirectory() as temp:
+            temp_path = Path(temp) / file.filename
+            temp_path.parent.mkdir(parents=True, exist_ok=True)
+            temp_path.write_text(source)
+            try:
+                preprocess_source = preprocess(temp_path)
+            except:
+                print(file.filename)
+                print("PREPROCESS FAILURE")
+                continue
+
+        parsable = validate_parse_tree(source)
+        preprocess_parsable = validate_parse_tree(preprocess_source)
+
+        print(file.filename)
+        print(f"original: {parsable}")
+        print(f"preprocess: {preprocess_parsable}")
+
+        # assert parsable or preprocess_parsable
+
+
+test_parse_tiegcm()

--- a/skema/program_analysis/tree_sitter_parsers/build_parsers.py
+++ b/skema/program_analysis/tree_sitter_parsers/build_parsers.py
@@ -21,10 +21,21 @@ def build_parsers(languages: List[str]) -> None:
 
     language_yaml_obj = yaml.safe_load(LANGUAGES_YAML_FILEPATH.read_text())
     for language, language_dict in language_yaml_obj.items():
+        language_clone_directory = language_build_dir / language_dict["tree_sitter_name"]
         if language in languages:
+            # Clone the repository if it doesn't exist
             subprocess.run(
                 ["git", "clone", language_dict["clone_url"]], cwd=language_build_dir
             )
+            # Update the repository to pull any new commits
+            subprocess.run(
+                ["git", "pull"], cwd=language_clone_directory
+            )
+            # Checkout the correct commit if commit_sha is specified
+            if language_dict.get("commit_sha"):
+                subprocess.run(
+                    ["git", "checkout", language_dict["commit_sha"]], cwd=language_clone_directory
+                )
 
     # We can set pass the cwd for subprocess as an argument to run().
     # However, Language.build_library requires the cwd to be set to the build directory

--- a/skema/program_analysis/tree_sitter_parsers/languages.yaml
+++ b/skema/program_analysis/tree_sitter_parsers/languages.yaml
@@ -16,6 +16,7 @@ cpp:
 fortran:
   tree_sitter_name: tree-sitter-fortran
   clone_url: https://github.com/stadelmanma/tree-sitter-fortran.git
+  commit_sha: f73d473
   supports_comment_extraction: True
   supports_fn_extraction: True
   extensions:


### PR DESCRIPTION
## Support for converting fixed-form Fortran to free-form
Attempts to convert fixed-form Fortran source code to free-form before parsing with tree-sitter. Since there is no consistent way of checking if a Fortran source if fixed-form, we run the tree-sitter parser both before and after converting to free-form to check if either returns a valid parse tree.

### Additional changes
- Removes existing implementation for handling fixed-form continuation lines.
- Adds testing framework for testing parsing TIE-GCM with tree-sitter.

## Support for pinning tree-sitter parser version
Adding an optional `commit_sha` field to languages.yaml to specify the commit to use when building a tree-sitter parser. If not specified, the most recent commit will be used instead. 

```YAML
fortran:
  tree_sitter_name: tree-sitter-fortran
  clone_url: https://github.com/stadelmanma/tree-sitter-fortran.git
  commit_sha: f73d473
  supports_comment_extraction: True
  supports_fn_extraction: True
  extensions:
    - .f
    - .F
    - .f90
    - .f95
    - .for
```

Resolves #411 
### Additional Changes
- Pins Fortran parser version to f73d473, enabling support for computed GO TO statements.