### PR TITLE
[CI] Use fork with fix to jlumbroso/free-disk-space/issues/9

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -257,7 +257,8 @@ jobs:
     # The TR image is huge.
     # We need to free up every last bit of space we can.
     - name: Free disk space (aggressively)
-      uses: jlumbroso/free-disk-space@v1.2.0
+      # use fork with fix to https://github.com/jlumbroso/free-disk-space/issues/9
+      uses: kfir4444/free-disk-space@main
       with:
         android: true
         dotnet: true


### PR DESCRIPTION
## Summary of changes
Resolves a CI issue related to an action that removes unused packages to create additional space on the runner for docker builds