### PR TITLE
GroMEt Function Call Handler Rewrite PR

### DIFF
--- a/skema/program_analysis/CAST/pythonAST/py_ast_to_cast.py
+++ b/skema/program_analysis/CAST/pythonAST/py_ast_to_cast.py
@@ -86,6 +86,23 @@ def construct_unique_name(attr_name, var_name):
     """
     return f"{attr_name}.{var_name}"
 
+def check_expr_str(ast_node):
+    """
+        Checks if this node is an Expr node
+        with a string value
+        This is added to remove multi-line comments
+        that otherwise don't do anything
+
+        Current cases for multi-line comments
+        - FunctionDef
+        - Module level
+        - ClassDef level
+    """
+
+    if isinstance(ast_node, ast.Expr):
+        return isinstance(ast_node.value, ast.Constant) and isinstance(ast_node.value.value, str)
+    return False
+
 
 def get_node_name(ast_node):
     if isinstance(ast_node, ast.Assign):
@@ -2446,9 +2463,15 @@ class PyASTToCAST:
                 # These asserts will keep us from visiting them from now
                 # assert not isinstance(piece, ast.Import)
                 # assert not isinstance(piece, ast.ImportFrom)
-                to_add = self.visit(
-                    piece, prev_scope_id_dict, curr_scope_id_dict
-                )
+                
+                # Check if the current node is a string literal
+                # which means that it's a docstring and we don't need it
+                if not check_expr_str(piece):
+                    to_add = self.visit(
+                        piece, prev_scope_id_dict, curr_scope_id_dict
+                    )
+                else:
+                    to_add = None
 
                 # TODO: Find the case where "__getitem__" is used
                 if hasattr(to_add, "__iter__") or hasattr(
@@ -3439,7 +3462,6 @@ class PyASTToCAST:
         merge_dicts(self.global_identifier_dict, curr_scope_id_dict)
         merge_dicts(curr_scope_id_dict, prev_scope_id_dict)
         for piece in node.body:
-            # Defer visiting function defs until all global vars are processed
             if isinstance(piece, ast.FunctionDef):
                 unique_name = construct_unique_name(
                     self.filenames[-1], piece.name
@@ -3448,10 +3470,13 @@ class PyASTToCAST:
                 prev_scope_id_dict[unique_name] = curr_scope_id_dict[
                     unique_name
                 ]
-                #funcs.append(piece)
-                #continue
 
-            to_add = self.visit(piece, prev_scope_id_dict, curr_scope_id_dict)
+            # If the current node is literally just a string literal
+            # then that means it's a docstring and we don't need it here
+            if not check_expr_str(piece):
+                to_add = self.visit(piece, prev_scope_id_dict, curr_scope_id_dict)
+            else: 
+                to_add = []
 
             # Global variables (which come about from assignments at the module level)
             # need to have their identifier names set correctly so they can be

--- a/skema/program_analysis/CAST2FN/ann_cast/to_gromet_pass.py
+++ b/skema/program_analysis/CAST2FN/ann_cast/to_gromet_pass.py
@@ -199,6 +199,7 @@ def get_left_side_name(node):
         return node.func.name
     return "NO LEFT SIDE NAME"
 
+
 def get_attribute_name(node):
     """
     Given an AnnCastAttribute node
@@ -210,12 +211,15 @@ def get_attribute_name(node):
     if isinstance(node, AnnCastCall):
         return get_attribute_name(node.func)
 
+
 def get_func_name(node: AnnCastCall):
     if isinstance(node.func, AnnCastName):
         return (node.func.name, f"{node.func.name}_id{node.func.id}")
     if isinstance(node.func, AnnCastAttribute):
-        return (node.func.attr.name,
-                f"{'.'.join(node.func.con_scope)}.{node.func.attr.name}_{node.invocation_index}")
+        return (
+            node.func.attr.name,
+            f"{'.'.join(node.func.con_scope)}.{node.func.attr.name}_{node.invocation_index}",
+        )
     if isinstance(node.func, str):
         return (node.func, f"{node.func}_id{node.func.id}")
 
@@ -1023,7 +1027,9 @@ class ToGrometPass:
             # We've made the call box function, which made its argument box functions and wired them appropriately.
             # Now, we have to make the output(s) to this call's box function and have them be assigned appropriately.
             # We also add any variables that have been assigned in this AnnCastAssignment to the variable environment
-            if not isinstance(node.right.func, AnnCastAttribute) and not is_inline(node.right.func.name):
+            if not isinstance(
+                node.right.func, AnnCastAttribute
+            ) and not is_inline(node.right.func.name):
                 # if isinstance(node.right.func, AnnCastName) and not is_inline(node.right.func.name):
                 # if isinstance(node.left, AnnCastTuple):
                 if is_tuple(node.left):
@@ -2105,7 +2111,6 @@ class ToGrometPass:
         ref = node.source_refs[0]
         metadata = self.create_source_code_reference(ref)
 
-
         # NOTE/TODO Maintain a table of primitive operators that when queried give you back
         # their signatures that can be used for generating
         # A global mapping is maintained but it isnt being used for their signatures yet
@@ -2124,7 +2129,9 @@ class ToGrometPass:
         parent_gromet_fn.pif = insert_gromet_object(
             parent_gromet_fn.pif, GrometPort(box=len(parent_gromet_fn.bf))
         )
-        if (isinstance(node.operands[0], (AnnCastName, AnnCastVar))) and opd_one_pof == -1:
+        if (
+            isinstance(node.operands[0], (AnnCastName, AnnCastVar))
+        ) and opd_one_pof == -1:
             if isinstance(node.operands[0], AnnCastName):
                 name = node.operands[0].name
             elif isinstance(node.operands[0], AnnCastVar):
@@ -2330,12 +2337,14 @@ class ToGrometPass:
         return (False, "")
 
     @_visit.register
-    def visit_call(self, node: AnnCastCall, parent_gromet_fn, parent_cast_node):
+    def visit_call(
+        self, node: AnnCastCall, parent_gromet_fn, parent_cast_node
+    ):
         ref = node.source_refs[0]
         metadata = self.create_source_code_reference(ref)
 
         # Used in special scenarios, when we might need
-        # to do something slightly different 
+        # to do something slightly different
         from_assignment = False
         from_call = False
         from_operator = False
@@ -2359,13 +2368,17 @@ class ToGrometPass:
         # What if it doesn't exist for some reason?
         # What if it's from a module?
         if is_primitive(func_name, "CAST") and not in_module[0]:
-            call_bf_idx = self.handle_primitive_function(node, parent_gromet_fn, parent_cast_node, from_assignment)
-            
+            call_bf_idx = self.handle_primitive_function(
+                node, parent_gromet_fn, parent_cast_node, from_assignment
+            )
+
             # Argument handling for primitives is a little different here, because we only want to find the variables that we need, and not create
             # any additional FNs. The additional FNs are created in the primitive handler
             for arg in node.arguments:
                 if isinstance(arg, AnnCastName):
-                    parent_gromet_fn.pif = insert_gromet_object(parent_gromet_fn.pif, GrometPort(box=call_bf_idx))
+                    parent_gromet_fn.pif = insert_gromet_object(
+                        parent_gromet_fn.pif, GrometPort(box=call_bf_idx)
+                    )
                     pif_idx = len(parent_gromet_fn.pif)
                     # Have to wire from either
                     # - a local variable
@@ -2379,21 +2392,30 @@ class ToGrometPass:
                         self.wire_from_var_env(arg.name, parent_gromet_fn)
                     elif arg.name in var_env["args"]:
                         # The reason we have to explicitly check if the call argument is in the variable environment as opposed
-                        # to just attempting to wire with 'wire_from_var_env' is that the expression can be its own FN without 
+                        # to just attempting to wire with 'wire_from_var_env' is that the expression can be its own FN without
                         # Attempt to find the opi if it already exists and wire to it
                         # otherwise add it
-                        found_opi, opi_idx = find_existing_opi(parent_gromet_fn, arg.name)
+                        found_opi, opi_idx = find_existing_opi(
+                            parent_gromet_fn, arg.name
+                        )
                         if found_opi:
                             parent_gromet_fn.wfopi = insert_gromet_object(
                                 parent_gromet_fn.wfopi,
-                                GrometWire(src=len(parent_gromet_fn.pif),tgt=opi_idx)                                      
+                                GrometWire(
+                                    src=len(parent_gromet_fn.pif), tgt=opi_idx
+                                ),
                             )
                         else:
-                            parent_gromet_fn.opi = insert_gromet_object(parent_gromet_fn.opi, GrometPort(name=arg.name, box=call_bf_idx))
+                            parent_gromet_fn.opi = insert_gromet_object(
+                                parent_gromet_fn.opi,
+                                GrometPort(name=arg.name, box=call_bf_idx),
+                            )
                             opi_idx = len(parent_gromet_fn.opi)
                             parent_gromet_fn.wfopi = insert_gromet_object(
                                 parent_gromet_fn.wfopi,
-                                GrometWire(src=len(parent_gromet_fn.pif),tgt=opi_idx)                                      
+                                GrometWire(
+                                    src=len(parent_gromet_fn.pif), tgt=opi_idx
+                                ),
                             )
                     elif arg.name in var_env["global"]:
                         self.wire_from_var_env(arg.name, parent_gromet_fn)
@@ -2427,41 +2449,52 @@ class ToGrometPass:
                 if func_name in self.record.keys():
                     idx = self.record[func_name][f"new:{func_name}"]
 
-                body = idx 
+                body = idx
 
             call_box_func = GrometBoxFunction(
-                name=name, 
+                name=name,
                 function_type=func_info[0] if func_info != None else None,
                 import_type=func_info[1] if func_info != None else None,
                 import_version=func_info[2] if func_info != None else None,
                 import_source=func_info[3] if func_info != None else None,
                 source_language=func_info[4] if func_info != None else None,
-                source_language_version=func_info[5] if func_info != None else None,
+                source_language_version=func_info[5]
+                if func_info != None
+                else None,
                 body=body,
-                metadata=metadata
+                metadata=metadata,
             )
-            parent_gromet_fn.bf = insert_gromet_object(parent_gromet_fn.bf, call_box_func)
+            parent_gromet_fn.bf = insert_gromet_object(
+                parent_gromet_fn.bf, call_box_func
+            )
             call_bf_idx = len(parent_gromet_fn.bf)
 
             # Iterate through all the arguments first
-            # In the case that we are looking at a primitive that 
+            # In the case that we are looking at a primitive that
             # is not inlined or part of an assignment we don't visit the
             # arguments as that's already been handled by the primitive handler
             # if not is_primitive(func_name, "CAST") or (from_assignment or is_inline(func_name)):
             for arg in node.arguments:
                 self.visit(arg, parent_gromet_fn, node)
-                
-                parent_gromet_fn.pif = insert_gromet_object(parent_gromet_fn.pif, GrometPort(box=call_bf_idx))
+
+                parent_gromet_fn.pif = insert_gromet_object(
+                    parent_gromet_fn.pif, GrometPort(box=call_bf_idx)
+                )
                 pif_idx = len(parent_gromet_fn.pif)
                 if is_tuple(arg):
                     for v in arg.value:
                         if hasattr(v, "name"):
                             self.wire_from_var_env(v.name, parent_gromet_fn)
-                elif isinstance(arg, (AnnCastLiteralValue, AnnCastCall, AnnCastOperator)):
+                elif isinstance(
+                    arg, (AnnCastLiteralValue, AnnCastCall, AnnCastOperator)
+                ):
                     # Can wff here due to all these ^^ giving us local pofs
 
                     pof_idx = len(parent_gromet_fn.pof)
-                    parent_gromet_fn.wff = insert_gromet_object(parent_gromet_fn.wff, GrometWire(src=pif_idx,tgt=pof_idx))            
+                    parent_gromet_fn.wff = insert_gromet_object(
+                        parent_gromet_fn.wff,
+                        GrometWire(src=pif_idx, tgt=pof_idx),
+                    )
                 elif isinstance(arg, AnnCastName):
                     # Have to wire from either
                     # - a local variable
@@ -2475,33 +2508,46 @@ class ToGrometPass:
                         self.wire_from_var_env(arg.name, parent_gromet_fn)
                     elif arg.name in var_env["args"]:
                         # The reason we have to explicitly check if the call argument is in the variable environment as opposed
-                        # to just attempting to wire with 'wire_from_var_env' is that the expression can be its own FN without 
+                        # to just attempting to wire with 'wire_from_var_env' is that the expression can be its own FN without
                         # Attempt to find the opi if it already exists and wire to it
                         # otherwise add it
-                        found_opi, opi_idx = find_existing_opi(parent_gromet_fn, arg.name)
+                        found_opi, opi_idx = find_existing_opi(
+                            parent_gromet_fn, arg.name
+                        )
                         if found_opi:
                             parent_gromet_fn.wfopi = insert_gromet_object(
                                 parent_gromet_fn.wfopi,
-                                GrometWire(src=len(parent_gromet_fn.pif),tgt=opi_idx)                                      
+                                GrometWire(
+                                    src=len(parent_gromet_fn.pif), tgt=opi_idx
+                                ),
                             )
                         else:
-                            parent_gromet_fn.opi = insert_gromet_object(parent_gromet_fn.opi, GrometPort(name=arg.name, box=call_bf_idx))
+                            parent_gromet_fn.opi = insert_gromet_object(
+                                parent_gromet_fn.opi,
+                                GrometPort(name=arg.name, box=call_bf_idx),
+                            )
                             opi_idx = len(parent_gromet_fn.opi)
                             parent_gromet_fn.wfopi = insert_gromet_object(
                                 parent_gromet_fn.wfopi,
-                                GrometWire(src=len(parent_gromet_fn.pif),tgt=opi_idx)                                      
+                                GrometWire(
+                                    src=len(parent_gromet_fn.pif), tgt=opi_idx
+                                ),
                             )
 
-        if from_call or from_operator or from_assignment: 
+        if from_call or from_operator or from_assignment:
             # Operator and calls need a pof appended here because they dont
             # do it themselves
             # At some point we would like the call handler to always append a POF
             if from_assignment and is_tuple(parent_cast_node.left):
                 # If an assignment is to a tuple, we create multiple pofs
                 for _ in parent_cast_node.left.value:
-                    parent_gromet_fn.pof = insert_gromet_object(parent_gromet_fn.pof, GrometPort(box=call_bf_idx))
+                    parent_gromet_fn.pof = insert_gromet_object(
+                        parent_gromet_fn.pof, GrometPort(box=call_bf_idx)
+                    )
             else:
-                parent_gromet_fn.pof = insert_gromet_object(parent_gromet_fn.pof, GrometPort(box=call_bf_idx))
+                parent_gromet_fn.pof = insert_gromet_object(
+                    parent_gromet_fn.pof, GrometPort(box=call_bf_idx)
+                )
 
         # If we're doing a call to a Record's "__init__" which is
         # determined by the function name matching the
@@ -2537,7 +2583,6 @@ class ToGrometPass:
             )
 
         return call_bf_idx
-
 
     def wire_return_name(self, name, gromet_fn, index=1):
         var_environment = self.symtab_variables()

--- a/skema/program_analysis/tests/test_primitive.py
+++ b/skema/program_analysis/tests/test_primitive.py
@@ -1,7 +1,10 @@
 # import json               NOTE: json and Path aren't used right now,
 # from pathlib import Path        but will be used in the future
 from skema.program_analysis.multi_file_ingester import process_file_system
-from skema.gromet.fn import GrometFNModuleCollection
+from skema.gromet.fn import (
+    GrometFNModuleCollection,
+    FunctionType
+)
 import ast
 
 from skema.program_analysis.CAST.pythonAST import py_ast_to_cast
@@ -29,6 +32,11 @@ def foo(x,y):
 foo(10,2)
     """
 
+def primitive3():
+    return """
+min(10,5)
+    """
+
 def generate_gromet(test_file_string):
     # use ast.Parse to get Python AST
     contents = ast.parse(test_file_string)
@@ -49,45 +57,116 @@ def test_primitive1():
     exp_gromet = generate_gromet(primitive1())
     
     base_fn = exp_gromet.fn
-    func_fn = exp_gromet.fn_array[0]
+
+    assert len(base_fn.b) == 1
+    assert len(base_fn.bf) == 3
+
+    assert len(base_fn.pif) == 2
+    assert len(base_fn.pof) == 3
+    assert len(base_fn.wff) == 2
+
+    assert base_fn.bf[2].function_type == FunctionType.LANGUAGE_PRIMITIVE
+    
+    assert base_fn.pif[0].box == 3
+    assert base_fn.pif[1].box == 3
+    assert base_fn.pof[2].box == 3
+
+    assert base_fn.wff[0].src == 1 and base_fn.wff[0].tgt == 1
+    assert base_fn.wff[1].src == 2 and base_fn.wff[1].tgt == 2
+
+
+def test_primitive2():
+    exp_gromet = generate_gromet(primitive2())
+    
+    base_fn = exp_gromet.fn
     primitive_fn = exp_gromet.fn_array[1]
+    add_fn = exp_gromet.fn_array[2]
 
     assert len(base_fn.b) == 1
 
-    ##############################################
-    assert len(func_fn.opi) == 2
-    assert len(func_fn.bf) == 1
+    assert base_fn.pif[0].box == 1 
+    assert base_fn.pif[1].box == 1 
 
-    assert len(func_fn.pif) == 2
-    assert len(func_fn.pof) == 1
+    assert base_fn.pof[0].box == 2 
+    assert base_fn.pof[1].box == 3 
 
-    assert len(func_fn.wfopi) == 1
-
-    assert func_fn.bf[0].body == 2
-
-    assert func_fn.wfopi[1].src == 2 and func_fn.wfopi[1].tgt == 2
+    assert base_fn.wff[0].src == 1 and base_fn.wff[0].tgt == 1
+    assert base_fn.wff[1].src == 2 and base_fn.wff[1].tgt == 2
 
     ##############################################
     assert len(primitive_fn.opi) == 2
     assert len(primitive_fn.opo) == 1
-    
-    assert len(primitive_fn.bf) == 2
-    assert len(primitive_fn.pif) == 3
-    assert len(primitive_fn.pof) == 2
+
+    assert len(primitive_fn.bf) == 1
+
+    assert len(primitive_fn.pif) == 2
+    assert len(primitive_fn.pof) == 1
 
     assert len(primitive_fn.wfopi) == 2
-    assert len(primitive_fn.wff) == 1
-    assert len(primitive_fn.wfopo) == 1
+
+    assert primitive_fn.bf[0].function_type == FunctionType.LANGUAGE_PRIMITIVE
+
+    assert primitive_fn.wfopi[0].src == 1 and primitive_fn.wfopi[0].tgt == 1
+    assert primitive_fn.wfopi[1].src == 2 and primitive_fn.wfopi[1].tgt == 2
+
+    assert primitive_fn.wfopo[0].src == 1 and primitive_fn.wfopo[0].tgt == 1
+
+    ##############################################
+    assert len(add_fn.opi) == 2
+    assert len(add_fn.opo) == 1
+    
+    assert len(add_fn.bf) == 2
+    assert len(add_fn.pif) == 4
+    assert len(add_fn.pof) == 2
+
+    assert len(add_fn.wfopi) == 3
+    assert len(add_fn.wff) == 1
+    assert len(add_fn.wfopo) == 1
+
+    # Check bfs
+    assert add_fn.bf[0].body == 2
+    assert add_fn.bf[1].function_type == FunctionType.LANGUAGE_PRIMITIVE
 
     # Check wiring
-    assert func_fn.wfopi[0].src == 1 and func_fn.wfopi[0].tgt == 1
-    assert func_fn.wfopi[1].src == 3 and func_fn.wfopi[1].tgt == 2
-    assert func_fn.wff[0].src == 2 and func_fn.wfopi[0].tgt == 1
-    assert func_fn.wfopo[0].src == 1 and func_fn.wfopi[0].tgt == 2
+    assert add_fn.wfopi[0].src == 1 and add_fn.wfopi[0].tgt == 1
+    assert add_fn.wfopi[1].src == 2 and add_fn.wfopi[1].tgt == 2
+    assert add_fn.wfopi[2].src == 4 and add_fn.wfopi[2].tgt == 2
+    
+    assert add_fn.wff[0].src == 3 and add_fn.wfopi[0].tgt == 1
+    
+    assert add_fn.wfopo[0].src == 1 and add_fn.wfopo[0].tgt == 2
 
+
+def test_primitive3():
+    exp_gromet = generate_gromet(primitive3())
+    
+    base_fn = exp_gromet.fn
+    primitive_fn = exp_gromet.fn_array[0]
+
+    assert len(base_fn.b) == 1
+    assert len(base_fn.bf) == 1
+
+    assert primitive_fn.bf[0].function_type == FunctionType.LANGUAGE_PRIMITIVE
+    assert primitive_fn.bf[1].function_type == FunctionType.LITERAL
+    assert primitive_fn.bf[2].function_type == FunctionType.LITERAL
+
+    assert primitive_fn.opo[0].box == 1
+    
+    assert primitive_fn.pif[0].box == 1
+    assert primitive_fn.pif[1].box == 1
+
+    assert primitive_fn.pof[0].box == 1
+    assert primitive_fn.pof[1].box == 2
+    assert primitive_fn.pof[2].box == 3
+
+    assert primitive_fn.wff[0].src == 1 and primitive_fn.wff[0].tgt == 2
+    assert primitive_fn.wff[1].src == 2 and primitive_fn.wff[1].tgt == 3
+    assert primitive_fn.wfopo[0].src == 1 and primitive_fn.wfopo[0].tgt == 1
 
 
 def test_primitive():
     test_primitive1()
+    test_primitive2()
+    test_primitive3()
 
     return

--- a/skema/program_analysis/tests/test_primitive.py
+++ b/skema/program_analysis/tests/test_primitive.py
@@ -1,0 +1,93 @@
+# import json               NOTE: json and Path aren't used right now,
+# from pathlib import Path        but will be used in the future
+from skema.program_analysis.multi_file_ingester import process_file_system
+from skema.gromet.fn import GrometFNModuleCollection
+import ast
+
+from skema.program_analysis.CAST.pythonAST import py_ast_to_cast
+from skema.program_analysis.CAST2FN.model.cast import SourceRef
+from skema.program_analysis.CAST2FN import cast
+from skema.program_analysis.CAST2FN.cast import CAST
+from skema.program_analysis.run_ann_cast_pipeline import ann_cast_pipeline
+
+# NOTE: these examples are very trivial for the realm of recursion
+#       more complex ones will follow later as needed
+
+def primitive1():
+    return """
+x = 10
+y = 5
+z = min(x,y)
+    """
+
+def primitive2():
+    return """
+def foo(x,y):
+    z = min(x,y) + y
+    return z
+
+foo(10,2)
+    """
+
+def generate_gromet(test_file_string):
+    # use ast.Parse to get Python AST
+    contents = ast.parse(test_file_string)
+
+    # use Python to CAST
+    line_count = len(test_file_string.split("\n"))
+    convert = py_ast_to_cast.PyASTToCAST("temp")
+    C = convert.visit(contents, {}, {})
+    C.source_refs = [SourceRef("temp", None, None, 1, line_count)]
+    out_cast = cast.CAST([C], "python")
+
+    # use AnnCastPipeline to create GroMEt
+    gromet = ann_cast_pipeline(out_cast, gromet=True, to_file=False, from_obj=True)
+
+    return gromet
+
+def test_primitive1():
+    exp_gromet = generate_gromet(primitive1())
+    
+    base_fn = exp_gromet.fn
+    func_fn = exp_gromet.fn_array[0]
+    primitive_fn = exp_gromet.fn_array[1]
+
+    assert len(base_fn.b) == 1
+
+    ##############################################
+    assert len(func_fn.opi) == 2
+    assert len(func_fn.bf) == 1
+
+    assert len(func_fn.pif) == 2
+    assert len(func_fn.pof) == 1
+
+    assert len(func_fn.wfopi) == 1
+
+    assert func_fn.bf[0].body == 2
+
+    assert func_fn.wfopi[1].src == 2 and func_fn.wfopi[1].tgt == 2
+
+    ##############################################
+    assert len(primitive_fn.opi) == 2
+    assert len(primitive_fn.opo) == 1
+    
+    assert len(primitive_fn.bf) == 2
+    assert len(primitive_fn.pif) == 3
+    assert len(primitive_fn.pof) == 2
+
+    assert len(primitive_fn.wfopi) == 2
+    assert len(primitive_fn.wff) == 1
+    assert len(primitive_fn.wfopo) == 1
+
+    # Check wiring
+    assert func_fn.wfopi[0].src == 1 and func_fn.wfopi[0].tgt == 1
+    assert func_fn.wfopi[1].src == 3 and func_fn.wfopi[1].tgt == 2
+    assert func_fn.wff[0].src == 2 and func_fn.wfopi[0].tgt == 1
+    assert func_fn.wfopo[0].src == 1 and func_fn.wfopi[0].tgt == 2
+
+
+
+def test_primitive():
+    test_primitive1()
+
+    return


### PR DESCRIPTION
### Refactoring of GroMEt Function Call Handler
- The handler that creates the GroMEt elements related to function calls needed a rewrite due to it becoming very difficult to maintain and change when bugs were discovered.
- The main goal was to make the code significantly smaller, and to remove redundancy and streamline the process as much as possible.
- The biggest redundancy changes was with the argument handling, as it was being done an unnecessary amount of times.
- There was also inconsistency with pof port generation and then it was needed and not needed. This caused inconsistent wiring generation.  
- A test file was added to support checking Gromets of small example programs that exercise the generation of function calls for both normal and primitive function calls.

### Removing Docstrings from Python AST to CAST
- Python stores multi-line comments as docstrings. These don't get eliminated from the AST, as they get stored as normal strings.
- This causes some issues when creating the CAST, because they are left in there as floating strings that don't contribute much to the extraction from this perspective. They're more relevant when they're extracted as comments.
- I've gone ahead and added code that removes all instances of docstrings that appear at the function definition level, global level, and class definition level. Now there'll no longer be any floating docstrings in the CAST. 
- The only strings that remain in the CAST are ones that are used as an actual value in a computation (assignment, function call, etc..)

### Additional Changes
- Removing commented out lines of code that aren't needed.
- Minor formatting fixes done with Black autoformatter.

Resolves #406 
Resolves #380 
Resolves #197 
Resolves #434 