### PR TITLE
continue on error for TR docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -271,6 +271,8 @@ jobs:
     - name: Build and push image (TR)
       # see https://github.com/docker/build-push-action
       uses: docker/build-push-action@v4
+      # our AWS deployment doesn't rely on this image being published
+      continue-on-error: true
       with:
         context: ./skema/text_reading/scala/webapp/target/docker/stage
         # NOTE: dynet throws an UnsatisfiedLinkError on ARM64 even with a platform compatible JRE.. :(


### PR DESCRIPTION
## Summary of changes

The CI step for building the TR docker image often fails or takes an inordinate amount of time to build and publish (ex. 2 hours).

Culprits include the the clulab JFrog repo which sometimes times out when we attempt to download (big) artifacts and the issues related to the large image size.

Our AWS deployment does not include the TR service (but may in the future if RAM consumption is reduced).  Until this PR, a failing TR image build & publish step would prevent a redeployment of our AWS service.