### PR TITLE
[CI] Additional tricks to save space building and publishing TR image

### DIFF
--- a/.github/workflows/text-reading-docker.yml
+++ b/.github/workflows/text-reading-docker.yml
@@ -42,13 +42,14 @@ jobs:
     steps:
     # Setup docker
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
     # for multi-arch builds (ex. ARM 64)
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
       with:
         buildkitd-flags: --debug
+        driver: docker
     # - name: Prepare buildx builder
     #   run: |
     #     docker buildx create --use --name "multiarch-builder" --platform linux/amd64,linux/arm64 --driver "docker-container"
@@ -61,32 +62,12 @@ jobs:
         echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
     # Checkout code
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Login to DockerHub
-      uses: docker/login-action@v2 
+      uses: docker/login-action@v3 
       with:
         username: ${{ secrets.LUM_ASKEM_DOCKERHUB_USERNAME }}
         password: ${{ secrets.LUM_ASKEM_DOCKERHUB_TOKEN }}
-    # - name: "Free disk space"
-    #   run: |
-    #     sudo apt clean
-    #     sudo rm -rf /usr/share/dotnet
-    #     sudo rm -rf /opt/ghc
-    #     sudo rm -rf "/usr/local/share/boost"
-    #     sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-    # The TR image is huge.
-    # We need to free up every last bit of space we can.
-    - name: Free disk space (aggressively)
-      # https://github.com/jlumbroso/free-disk-space
-      uses: jlumbroso/free-disk-space@v1.3.0
-      with:
-        android: true
-        dotnet: true
-        haskell: true
-        large-packages: true
-        docker-images: true
-        swap-storage: true
-        tool-cache: false
 
     ########################################
     # lumai/askem-skema-text-reading
@@ -99,6 +80,22 @@ jobs:
         # Unfortunately, this will immediately 
         # blow through the GH Actions cache...
         #cache: 'sbt'
+
+    # The TR image is huge.
+    # We need to free up every last bit of space we can.
+    - name: Free disk space (aggressively)
+      # https://github.com/jlumbroso/free-disk-space
+      uses: jlumbroso/free-disk-space@v1.3.0
+      with:
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: true
+        swap-storage: true
+        # NOTE: this might remove things we actually need.
+        tool-cache: true
+
     - name: Generate Dockerfile (TR)
       working-directory: ./skema/text_reading/scala
       env:


### PR DESCRIPTION
### Summary of changes

These changes attempt to remove additional default packages from the base runner to create some additional space for TR image build and publish step.