### PR TITLE
[TR] UseJava 11 in CI tests and for docker base image

### DIFF
--- a/skema/text_reading/scala/webapp/docker.sbt
+++ b/skema/text_reading/scala/webapp/docker.sbt
@@ -11,8 +11,7 @@ val tag = "1.0.0"
 
 
 Docker / defaultLinuxInstallLocation := appDir
-// TODO: can we run this with 11 (i.e., eclipse-temurin:11-jre-focal)?
-Docker / dockerBaseImage := "eclipse-temurin:8-jre-focal"
+Docker / dockerBaseImage := "eclipse-temurin:11-jre-focal"
 Docker / daemonUser := "nobody"
 Docker / dockerExposedPorts := List(port)
 Docker / maintainer := "Keith Alcock <docker@keithalcock.com>"


### PR DESCRIPTION
## Summary of changes
Our CI is using Temurin 11 for running our Scala tests, but our docker image was using temurin 8 as its base image.  Both now use Temurin 11.


Resolves #551