### PR TITLE
Resolves #551

### DIFF
--- a/skema/text_reading/scala/webapp/docker.sbt
+++ b/skema/text_reading/scala/webapp/docker.sbt
@@ -11,7 +11,7 @@ val tag = "1.0.0"
 
 
 Docker / defaultLinuxInstallLocation := appDir
-Docker / dockerBaseImage := "eclipse-temurin:11-jre-focal"
+dockerBaseImage := "eclipse-temurin:11-jre-focal"
 Docker / daemonUser := "nobody"
 Docker / dockerExposedPorts := List(port)
 Docker / maintainer := "Keith Alcock <docker@keithalcock.com>"
@@ -67,4 +67,4 @@ def moveDir(dirname: String): Seq[(File, String)] = {
 
 // Universal / mappings ++= moveDir("./cache/geonames")
 
-Global / excludeLintKeys += Docker / dockerBaseImage
+Global / excludeLintKeys += dockerBaseImage


### PR DESCRIPTION
## Summary of changes

Previously, `dockerBaseImage` was set in a manner that prevented it from being picked up.  This meant that any change to that setting was ignored and left at its default value.  With this PR, the setting now works as expected:


```bash
# generate the dockerfile
sbt "webapp/docker:stage"
# check the first line of the generated dockerfile
head -n 1 webapp/target/docker/stage/Dockerfile
```

```dockerfile
FROM eclipse-temurin:11-jre-focal as stage0
```


Resolves #551