### PR TITLE
Ensure `skema[llms]` included in docker image build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ metal = ["skema[ml]",
       "mock",
       "askem_extractions[all]@git+https://github.com/ml4ai/ASKEM-TA1-DataModel"]
 
+# for llm use in skema
+llms = ["langchain==0.0.325"]
+
 # dependencies for text reading utilities.
 tr = ["skema[ml]", "pyarrow==13.0.0",
       "tqdm",
@@ -79,16 +82,13 @@ tr = ["skema[ml]", "pyarrow==13.0.0",
 # project documentation generation
 doc = ["mkdocs==1.2.3", "pdoc3==0.10.0", "mkdocs-git-snippet==0.1.1", "mkdocs-git-revision-date-localized-plugin==0.11.1", "mkdocs-git-authors-plugin==0.6.3", "mkdocs-rtd-dropdown==1.0.2", "jinja2<3.1.0"]
 
-core = ["skema[img2mml]", "skema[isa]", "skema[tr]", "skema[metal]"]
+core = ["skema[img2mml]", "skema[isa]", "skema[tr]", "skema[metal]", "skema[llms]"]
 
 # see skema/img2mml/render_mml/mathpix_annotator
 annotations = ["matplotlib", "notebook"]
 
-# for llm use in skema
-llms = ["langchain==0.0.325"]
-
 # all extras
-all = ["skema[core]", "skema[dev]", "skema[doc]", "skema[demo]", "skema[annotations]", "skema[llms]"]
+all = ["skema[core]", "skema[dev]", "skema[doc]", "skema[demo]", "skema[annotations]"]
 
 [tool.setuptools.package-dir]
 "skema.gromet" = "skema/gromet"


### PR DESCRIPTION
## Summary of Changes

https://github.com/ml4ai/skema/pull/601 introduced LLMs using `langchain` and the Open AI API.  The `llms` extra was included in the extra `all`, but our docker image only installs `core` to avoid bloat:  https://github.com/ml4ai/skema/blob/3af73f74ec127e0fb4c5abf4d3a8f9bd0eea3e71/Dockerfile.skema-py#L53

This caused an import error that triggered a deployment failure loop.