### PR TITLE
Pin node minor version to avoid occasional CI issue

### DIFF
--- a/Dockerfile.skema-py
+++ b/Dockerfile.skema-py
@@ -21,8 +21,9 @@ RUN apt-get update &&\
 
 # Node needed for img2mml
 RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
-RUN apt-get update -y && apt-get install -y nodejs -y
+RUN apt-get update -y && apt-get -y install nodejs
 
 # The two commands below are to reduce the size of the Docker image
 RUN apt-get clean &&\

--- a/Dockerfile.skema-py
+++ b/Dockerfile.skema-py
@@ -21,8 +21,8 @@ RUN apt-get update &&\
 
 # Node needed for img2mml
 RUN mkdir -p /etc/apt/keyrings
-RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
-RUN apt-get update -y && sudo apt-get install -y nodejs -y
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update -y && apt-get install -y nodejs -y
 
 # The two commands below are to reduce the size of the Docker image
 RUN apt-get clean &&\

--- a/Dockerfile.skema-py
+++ b/Dockerfile.skema-py
@@ -12,11 +12,16 @@ RUN apt-get update &&\
         build-essential \
         graphviz \
         libgraphviz-dev \
-        python3-venv 
+        python3-venv \
+        gnupg \
+        ca-certificates \
+        curl
 
 # Node needed for img2mml
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - &&\
-apt-get install -y nodejs=18.17.0-1nodesource1
+RUN NODE_MAJOR=18 && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update -y && sudo apt-get install -y nodejs -y
+#RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - &&\
+#apt-get install -y nodejs=18.17.0-1nodesource1
 
 # The two commands below are to reduce the size of the Docker image
 RUN apt-get clean &&\

--- a/Dockerfile.skema-py
+++ b/Dockerfile.skema-py
@@ -5,6 +5,8 @@ FROM  python:3.8-bullseye
 # Install prerequisites
 # ======================
 ARG DEBIAN_FRONTEND=noninteractive
+ARG NODE_MAJOR=18
+
 RUN apt-get update &&\
     apt-get -y --no-install-recommends install \
         tree \
@@ -18,10 +20,9 @@ RUN apt-get update &&\
         curl
 
 # Node needed for img2mml
-RUN NODE_MAJOR=18 && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+RUN mkdir -p /etc/apt/keyrings
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 RUN apt-get update -y && sudo apt-get install -y nodejs -y
-#RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - &&\
-#apt-get install -y nodejs=18.17.0-1nodesource1
 
 # The two commands below are to reduce the size of the Docker image
 RUN apt-get clean &&\

--- a/Dockerfile.skema-py
+++ b/Dockerfile.skema-py
@@ -21,9 +21,9 @@ RUN apt-get update &&\
 
 # Node needed for img2mml
 RUN mkdir -p /etc/apt/keyrings
-RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
-RUN apt-get update -y && apt-get -y install nodejs
+RUN apt-get update && apt-get -y install nodejs
 
 # The two commands below are to reduce the size of the Docker image
 RUN apt-get clean &&\

--- a/Dockerfile.skema-py
+++ b/Dockerfile.skema-py
@@ -16,7 +16,7 @@ RUN apt-get update &&\
 
 # Node needed for img2mml
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - &&\
-apt-get install -y nodejs
+apt-get install -y nodejs=18.17.0-1nodesource1
 
 # The two commands below are to reduce the size of the Docker image
 RUN apt-get clean &&\


### PR DESCRIPTION
## Summary of Changes

[Nodesource changed their Node JS binary installation process back in August](https://github.com/nodesource/distributions/pull/1626).  This seems to have finally caught up with us.

[This PR shifts to the new installation method](https://github.com/nodesource/distributions#nodejs).