### PR TITLE
[rust] fix lint warnings

### DIFF
--- a/skema/skema-rs/mathml/src/ast/operator.rs
+++ b/skema/skema-rs/mathml/src/ast/operator.rs
@@ -64,7 +64,7 @@ impl fmt::Display for Operator {
             Operator::Factorial => write!(f, "!"),
             Operator::Derivative(Derivative {
                 order,
-                var_index,
+                var_index: _,
                 bound_var,
             }) => {
                 write!(f, "D({order}, {bound_var})")

--- a/skema/skema-rs/mathml/src/expression.rs
+++ b/skema/skema-rs/mathml/src/expression.rs
@@ -1179,7 +1179,7 @@ pub fn preprocess_content(content_str: String) -> String {
         let loc = pre_string[*ul..].find('<').map(|i| i + ul);
         match loc {
             None => {}
-            Some(x) => {}
+            Some(_x) => {}
         }
     }
     pre_string = html_escape::decode_html_entities(&pre_string).to_string();

--- a/skema/skema-rs/mathml/src/parsers/decapodes_serialization.rs
+++ b/skema/skema-rs/mathml/src/parsers/decapodes_serialization.rs
@@ -517,7 +517,7 @@ fn test_serialize_from_image_3_2() {
     </math>
     ";
     let expression = input.parse::<MathExpressionTree>().unwrap();
-    let s_exp = expression.to_string();
+    let _s_exp = expression.to_string();
     let wiring_diagram = to_wiring_diagram(&expression);
     let json = to_decapodes_json(wiring_diagram);
     assert_eq!(json, "{\"Var\":[{\"type\":\"infer\",\"name\":\"mult_1\"},{\"type\":\"infer\",\"name\":\"mult_2\"},{\"type\":\"infer\",\"name\":\"•1\"},{\"type\":\"Literal\",\"name\":\"2\"},{\"type\":\"infer\",\"name\":\"sum_1\"},{\"type\":\"infer\",\"name\":\"n\"},{\"type\":\"infer\",\"name\":\"A\"},{\"type\":\"infer\",\"name\":\"•2\"},{\"type\":\"infer\",\"name\":\"mult_3\"},{\"type\":\"infer\",\"name\":\"ρ\"},{\"type\":\"infer\",\"name\":\"g\"},{\"type\":\"infer\",\"name\":\"Γ\"}],\"Op1\":[],\"Op2\":[{\"proj1\":4,\"proj2\":5,\"res\":3,\"op2\":\"/\"},{\"proj1\":3,\"proj2\":7,\"res\":2,\"op2\":\"*\"},{\"proj1\":10,\"proj2\":11,\"res\":9,\"op2\":\"*\"},{\"proj1\":9,\"proj2\":6,\"res\":8,\"op2\":\"^\"},{\"proj1\":2,\"proj2\":8,\"res\":1,\"op2\":\"*\"}],\"Σ\":[{\"sum\":5}],\"Summand\":[{\"summand\":6,\"summation\":1},{\"summand\":4,\"summation\":1}]}");

--- a/skema/skema-rs/mathml/src/parsers/interpreted_mathml.rs
+++ b/skema/skema-rs/mathml/src/parsers/interpreted_mathml.rs
@@ -21,7 +21,7 @@ use nom::{
     bytes::complete::tag,
     combinator::{map, opt, value},
     multi::{many0, many1, separated_list1},
-    sequence::{delimited, pair, preceded, separated_pair, tuple},
+    sequence::{delimited, pair, preceded, tuple},
 };
 
 /// Function to parse operators. This function differs from the one in parsers::generic_mathml by
@@ -409,7 +409,7 @@ pub fn absolute(input: Span) -> IResult<Mrow> {
 
 /// Example: Divergence
 pub fn div(input: Span) -> IResult<Operator> {
-    let (s, op) = ws(pair(gradient, ws(delimited(stag!("mo"), dot, etag!("mo")))))(input)?;
+    let (s, _op) = ws(pair(gradient, ws(delimited(stag!("mo"), dot, etag!("mo")))))(input)?;
     let div = Operator::Div;
     Ok((s, div))
 }

--- a/skema/skema-rs/mathml/src/parsers/math_expression_tree.rs
+++ b/skema/skema-rs/mathml/src/parsers/math_expression_tree.rs
@@ -864,7 +864,7 @@ fn expr(input: Vec<MathExpression>) -> MathExpressionTree {
     let mut result: MathExpressionTree = expr_bp(&mut lexer, 0);
     let mut math_vec: Vec<MathExpressionTree> = vec![];
     while lexer.next() != Token::Eof {
-        let mut math_result = expr_bp(&mut lexer, 0);
+        let math_result = expr_bp(&mut lexer, 0);
         math_vec.push(math_result.clone());
     }
 
@@ -1153,7 +1153,7 @@ fn test_content_hackathon2_scenario1_eq1() {
         lhs_var: _,
         func_of: _,
         with_respect_to: _,
-        rhs,
+        rhs: _,
     } = first_order_ode(input.into()).unwrap().1;
     assert_eq!(cmml, "<apply><eq/><apply><diff/><bvar>t</bar><ci>S</ci></apply><apply><divide/><apply><times/><apply><times/><apply><minus/><ci>β</ci></apply><ci>I</ci></apply><ci>S</ci></apply><ci>N</ci></apply></apply>");
 }

--- a/skema/skema-rs/skema/src/bin/morae.rs
+++ b/skema/skema-rs/skema/src/bin/morae.rs
@@ -1,18 +1,18 @@
 use clap::Parser;
 
-use mathml::mml2pn::get_mathml_asts_from_file;
+
 pub use mathml::mml2pn::{ACSet, Term};
 
 // new imports
 use std::env;
 use skema::config::Config;
-use mathml::acset::{PetriNet, RegNet};
+use mathml::acset::{PetriNet};
 use mathml::parsers::first_order_ode::get_FirstOrderODE_vec_from_file;
-use mathml::parsers::math_expression_tree::MathExpressionTree;
-use mathml::parsers::decapodes_serialization::{to_wiring_diagram, WiringDiagram, DecapodesCollection};
-use skema::model_extraction::{module_id2mathml_MET_ast, subgraph2_core_dyn_ast};
-use std::io::{BufRead, BufReader};
-use std::fs::File;
+
+
+use skema::model_extraction::{module_id2mathml_MET_ast};
+
+
 
 
 #[derive(Parser, Debug)]

--- a/skema/skema-rs/skema/src/database.rs
+++ b/skema/skema-rs/skema/src/database.rs
@@ -25,7 +25,7 @@ There being a second function call of the same function which contains an expres
 use crate::FunctionType;
 use crate::{Files, Grounding, ModuleCollection, Provenance, TextExtraction, ValueMeta};
 use crate::{FunctionNet, GrometBox, ValueL};
-use rsmgclient::{ConnectParams, Connection, MgError};
+use rsmgclient::{Connection, MgError};
 use crate::config::Config;
 
 #[derive(Debug, Clone)]

--- a/skema/skema-rs/skema/src/model_extraction.rs
+++ b/skema/skema-rs/skema/src/model_extraction.rs
@@ -69,7 +69,7 @@ pub fn get_line_span(
 pub fn module_id2mathml_MET_ast(module_id: i64, config: Config) -> Vec<FirstOrderODE> {
     let mut core_dynamics_ast = Vec::<FirstOrderODE>::new();
     let mut _metadata_map_ast = HashMap::new();
-    let graph = subgraph2petgraph(module_id, config.clone()); // makes petgraph of graph
+    let _graph = subgraph2petgraph(module_id, config.clone()); // makes petgraph of graph
 
     let core_id = find_pn_dynamics(module_id, config.clone()); // gives back list of function nodes that might contain the dynamics
     //let _line_span = get_line_span(core_id[0], graph); // get's the line span of function id

--- a/skema/skema-rs/skema/src/services/gromet.rs
+++ b/skema/skema-rs/skema/src/services/gromet.rs
@@ -7,8 +7,8 @@ use crate::ModuleCollection;
 use actix_web::web::ServiceConfig;
 use actix_web::{delete, get, post, put, web, HttpResponse};
 use mathml::acset::{PetriNet, RegNet};
-use mathml::mml2pn::ACSet;
-use rsmgclient::{ConnectParams, Connection, MgError, Value};
+
+use rsmgclient::{Connection, MgError, Value};
 use std::collections::HashMap;
 use utoipa;
 


### PR DESCRIPTION
## Summary of Changes

 Automatically fixes for lint warnings reported by `rustc`:

```bash
cargo fix --all-targets
```
### Related issues

N/A