### PR TITLE
Consistent Response times for LLM related endpoints

### DIFF
--- a/skema/rest/llm_proxy.py
+++ b/skema/rest/llm_proxy.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from pydantic import BaseModel, Field
 from typing import List, Optional
 from skema.rest.proxies import SKEMA_OPENAI_KEY
+import time
 
 router = APIRouter()
 
@@ -122,6 +123,7 @@ async def get_lines_of_model(zip_file: UploadFile = File()) -> List[Dynamics]:
 
             # Get the FN from it
             url = "https://api.askem.lum.ai/code2fn/fn-given-filepaths"
+            time.sleep(0.5)
             response_zip = requests.post(url, json=single_snippet_payload)
 
             # get metadata entry for function

--- a/skema/rest/tests/test_model_to_amr.py
+++ b/skema/rest/tests/test_model_to_amr.py
@@ -13,6 +13,7 @@ from skema.rest.workflows import (
 from skema.rest.llm_proxy import Dynamics
 from skema.rest.proxies import SKEMA_RS_ADDESS
 from skema.skema_py.server import System
+import time
 
 CHIME_SIR_URL = (
     "https://artifacts.askem.lum.ai/askem/data/models/zip-archives/CHIME-SIR-model.zip"
@@ -63,6 +64,7 @@ def test_any_amr_chime_sir():
         else:
             blobs[i] = "".join(blobs[i].splitlines(keepends=True)[line_begin[i]:line_end[i]])
             try:
+                time.sleep(0.5)
                 amrs.append(
                     asyncio.run(
                         code_snippets_to_pn_amr(

--- a/skema/rest/workflows.py
+++ b/skema/rest/workflows.py
@@ -4,6 +4,7 @@ End-to-end skema workflows
 """
 import copy
 import requests
+import time
 from zipfile import ZipFile
 from io import BytesIO
 from typing import List
@@ -263,6 +264,7 @@ async def llm_assisted_codebase_to_pn_amr(zip_file: UploadFile = File()):
         else:
             blobs[i] = "".join(blobs[i].splitlines(keepends=True)[line_begin[i]:line_end[i]])
             try:
+                time.sleep(0.5)
                 amrs.append(
                     await code_snippets_to_pn_amr(
                         code2fn.System(


### PR DESCRIPTION
## Summary of Changes
I believe for multiple files in the zip drive we hit the code2fn and code-snippets endpoint too rapidly and they sometimes crash, resulting in inconsistent response times and results from the LLM endpoint. I added 0.5 second sleeps before each endpoint call to not overload them. The exact sleep time can be refined and shrunk down as we understand it better. 

### Related issues

Resolves ???