### PR TITLE
[img2latex] Handle negative minus and sqrt in to_latex and add tests for mtext

### DIFF
--- a/skema/skema-rs/mathml/src/parsers/math_expression_tree.rs
+++ b/skema/skema-rs/mathml/src/parsers/math_expression_tree.rs
@@ -278,7 +278,7 @@ fn is_unary_operator(op: &Operator) -> bool {
 // If the expression is an atom, it is added to the LaTeX string directly.
 fn process_expression_parentheses(expression: &mut String, met: &MathExpressionTree) {
     // Check if the rest vector is not empty and contains a MathExpressionTree::Cons variant.
-    if let MathExpressionTree::Cons(op, _) = met {
+    if let MathExpressionTree::Cons(op, args) = met {
         // Check if the operator is a unary operator.
         if is_unary_operator(op) {
             // If it is a unary operator, add it to the LaTeX string as is.
@@ -520,11 +520,17 @@ impl MathExpressionTree {
                         }
                     }
                     Operator::Subtract => {
-                        for (index, r) in rest.iter().enumerate() {
-                            process_expression_parentheses(&mut expression, r);
-                            // Add "-" if it's not the last element
-                            if index < rest.len() - 1 {
-                                expression.push_str("-");
+                        // Handle unary minus
+                        if rest.len() == 1 {
+                            expression.push_str("-");
+                            process_expression_parentheses(&mut expression, &rest[0]);
+                        } else {
+                            for (index, r) in rest.iter().enumerate() {
+                                process_expression_parentheses(&mut expression, r);
+                                // Add "-" if it's not the last element
+                                if index < rest.len() - 1 {
+                                    expression.push_str("-");
+                                }
                             }
                         }
                     }
@@ -2115,6 +2121,7 @@ fn test_equation_with_mtext() {
     let exp = input.parse::<MathExpressionTree>().unwrap();
     let s_exp = exp.to_string();
     assert_eq!(s_exp, "(= L_{reg} (+ L_{d1} L_{d2}))");
+    assert_eq!(exp.to_latex(), "L_{reg}=L_{d1}+L_{d2}");
 }
 
 #[test]
@@ -2129,6 +2136,7 @@ fn new_msqrt_test_function() {
     let exp = input.parse::<MathExpressionTree>().unwrap();
     let s_exp = exp.to_string();
     assert_eq!(s_exp, "(√ (* (* 4 a) c))");
+    assert_eq!(exp.to_latex(), "\\sqrt{4*a*c}");
 }
 #[test]
 fn new_quadratic_equation() {
@@ -2164,4 +2172,5 @@ fn new_quadratic_equation() {
         s_exp,
         "(= x (/ (- (- b) (√ (- (^ b 2) (* (* 4 a) c)))) (* 2 a)))"
     );
+    assert_eq!(exp.to_latex(), "x=\\frac{(-b)-\\sqrt{b^{2}-(4*a*c)}}{2*a}");
 }


### PR DESCRIPTION
## Summary of Changes

- Handle negative minus and sqrt in `to_latex` and add tests for mtext.