### PR TITLE
Python tree-sitter to CAST porting: Loops

### DIFF
--- a/skema/program_analysis/CAST/python/node_helper.py
+++ b/skema/program_analysis/CAST/python/node_helper.py
@@ -1,3 +1,4 @@
+import itertools
 from typing import List, Dict
 from skema.program_analysis.CAST2FN.model.cast import SourceRef
 
@@ -24,6 +25,30 @@ CONTROL_CHARACTERS = [
     "not"
 ]
 
+# Whatever constructs we see in the left
+# part of the for loop construct
+# for LEFT in RIGHT: 
+FOR_LOOP_LEFT_TYPES = [
+    "identifier",
+    "tuple_pattern",
+    "pattern_list"
+]
+
+# Whatever constructs we see in the right
+# part of the for loop construct
+# for LEFT in RIGHT: 
+FOR_LOOP_RIGHT_TYPES = [
+    "call",
+]
+
+# Whatever constructs we see in the conditional
+# part of the while loop
+WHILE_COND_TYPES = [
+    "boolean_operator",
+    "call",
+    "comparison_operator"
+]
+
 class NodeHelper():
     def __init__(self, source: str, source_file_name: str):
         self.source = source
@@ -32,7 +57,7 @@ class NodeHelper():
         # get_identifier optimization variables
         self.source_lines = source.splitlines(keepends=True)
         self.line_lengths = [len(line) for line in self.source_lines]
-        self.line_length_sums = [sum(self.line_lengths[:i+1]) for i in range(len(self.source_lines))]
+        self.line_length_sums = list(itertools.accumulate(self.line_lengths))
         
     def get_identifier(self, node: Node) -> str:
         """Given a node, return the identifier it represents. ie. The code between node.start_point and node.end_point"""

--- a/skema/program_analysis/CAST/python/node_helper.py
+++ b/skema/program_analysis/CAST/python/node_helper.py
@@ -61,8 +61,8 @@ class NodeHelper():
         # get_identifier optimization variables
         self.source_lines = source.splitlines(keepends=True)
         self.line_lengths = [len(line) for line in self.source_lines]
-        self.line_length_sums = [sum(self.line_lengths[:i+1]) for i in range(len(self.source_lines))] 
-
+        self.line_length_sums = [0] + list(itertools.accumulate(self.line_lengths))
+    
     def get_identifier(self, node: Node) -> str:
         """Given a node, return the identifier it represents. ie. The code between node.start_point and node.end_point"""
         start_line, start_column = node.start_point
@@ -70,10 +70,7 @@ class NodeHelper():
 
         # Edge case for when an identifier is on the very first line of the code
         # We can't index into the line_length_sums
-        if start_line == 0:
-            start_index = start_column
-        else:
-            start_index = self.line_length_sums[start_line-1] + start_column
+        start_index = self.line_length_sums[start_line] + start_column        
         if start_line == end_line:
             end_index = start_index + (end_column-start_column)
         else:

--- a/skema/program_analysis/CAST/python/node_helper.py
+++ b/skema/program_analysis/CAST/python/node_helper.py
@@ -31,7 +31,8 @@ CONTROL_CHARACTERS = [
 FOR_LOOP_LEFT_TYPES = [
     "identifier",
     "tuple_pattern",
-    "pattern_list"
+    "pattern_list",
+    "list_pattern"
 ]
 
 # Whatever constructs we see in the right
@@ -39,6 +40,9 @@ FOR_LOOP_LEFT_TYPES = [
 # for LEFT in RIGHT: 
 FOR_LOOP_RIGHT_TYPES = [
     "call",
+    "identifier",
+    "list",
+    "tuple"
 ]
 
 # Whatever constructs we see in the conditional
@@ -57,14 +61,19 @@ class NodeHelper():
         # get_identifier optimization variables
         self.source_lines = source.splitlines(keepends=True)
         self.line_lengths = [len(line) for line in self.source_lines]
-        self.line_length_sums = list(itertools.accumulate(self.line_lengths))
-        
+        self.line_length_sums = [sum(self.line_lengths[:i+1]) for i in range(len(self.source_lines))] 
+
     def get_identifier(self, node: Node) -> str:
         """Given a node, return the identifier it represents. ie. The code between node.start_point and node.end_point"""
         start_line, start_column = node.start_point
         end_line, end_column = node.end_point
 
-        start_index = self.line_length_sums[start_line-1] + start_column
+        # Edge case for when an identifier is on the very first line of the code
+        # We can't index into the line_length_sums
+        if start_line == 0:
+            start_index = start_column
+        else:
+            start_index = self.line_length_sums[start_line-1] + start_column
         if start_line == end_line:
             end_index = start_index + (end_column-start_column)
         else:

--- a/skema/program_analysis/CAST/python/ts2cast.py
+++ b/skema/program_analysis/CAST/python/ts2cast.py
@@ -25,7 +25,8 @@ from skema.program_analysis.CAST2FN.model.cast import (
     ModelIf,
     RecordDef,
     Attribute,
-    ScalarType
+    ScalarType,
+    StructureType
 )
 
 from skema.program_analysis.CAST.python.node_helper import (
@@ -74,6 +75,9 @@ class TS2CAST(object):
             )
         )
 
+        # Additional variables used in generation
+        self.var_count = 0
+
         # Tree walking structures
         self.variable_context = VariableContext()
         self.node_helper = NodeHelper(self.source, self.source_file_name)
@@ -85,6 +89,7 @@ class TS2CAST(object):
     def generate_cast(self) -> List[CAST]:
         '''Interface for generating CAST.'''
         module = self.run(self.tree.root_node)
+        module.name = self.source_file_name
         return CAST([generate_dummy_source_refs(module)], "Python") 
         
     def run(self, root) -> List[Module]:
@@ -122,8 +127,10 @@ class TS2CAST(object):
             return self.visit_unary_op(node)
         elif node.type == "binary_operator":
             return self.visit_binary_op(node)
-        elif node.type in ["integer"]:
+        elif node.type in ["integer", "list"]:
             return self.visit_literal(node)
+        elif node.type in ["list_pattern", "pattern_list", "tuple_pattern"]:
+            return self.visit_pattern(node)
         elif node.type == "while_statement":
             return self.visit_while(node)
         elif node.type == "for_statement":
@@ -230,6 +237,21 @@ class TS2CAST(object):
                 func_args.extend(cast)
             elif isinstance(cast, AstNode):
                 func_args.append(cast)
+
+        if func_name.val.name == "range":
+            start_step_value = LiteralValue(
+                ScalarType.INTEGER, 
+                value=1,
+                source_code_data_type=["Python", PYTHON_VERSION, str(type(1))],
+                source_refs=[ref]
+            )
+            # Add a step value
+            if len(func_args) == 2:
+                func_args.append(start_step_value)
+            # Add a start and step value
+            elif len(func_args) == 1:
+                func_args.insert(0, start_step_value)
+                func_args.append(start_step_value)
 
         # Function calls only want the 'Name' part of the 'Var' that the visit returns
         return Call(
@@ -378,6 +400,17 @@ class TS2CAST(object):
             source_refs=[ref]
         )
 
+    def visit_pattern(self, node: Node):
+        pattern_cast = []
+        for elem in node.children:
+            cast = self.visit(elem)
+            if isinstance(cast, List):
+                pattern_cast.extend(cast)
+            elif isinstance(cast, AstNode):
+                pattern_cast.append(cast)
+
+        return LiteralValue(value_type=StructureType.TUPLE, value=pattern_cast) 
+
     def visit_identifier(self, node: Node) -> Var:
         identifier = self.node_helper.get_identifier(node)
 
@@ -424,6 +457,38 @@ class TS2CAST(object):
                 source_code_data_type=["Python", PYTHON_VERSION, str(type(True))],
                 source_refs=[literal_source_ref]
             )
+        elif literal_type == "list":
+            list_items = []
+            for elem in node.children:
+                cast = self.visit(cast)
+                if isinstance(cast, List):
+                    list_items.extend(cast)
+                elif isinstance(cast, AstNode):
+                    list_items.append(cast)
+
+            return LiteralValue(
+                value_type=StructureType.LIST,
+                value = list_items,
+                source_code_data_type=["Python", PYTHON_VERSION, str(type([0]))],
+                source_refs=[literal_source_ref]
+            )
+        elif literal_type == "tuple":
+            tuple_items = []
+            for elem in node.children:
+                cast = self.visit(cast)
+                if isinstance(cast, List):
+                    tuple_items.extend(cast)
+                elif isinstance(cast, AstNode):
+                    tuple_items.append(cast)
+
+            return LiteralValue(
+                value_type=StructureType.LIST,
+                value = tuple_items,
+                source_code_data_type=["Python", PYTHON_VERSION, str(type((0)))],
+                source_refs=[literal_source_ref]
+            )
+
+
 
     def visit_while(self, node: Node) -> Loop:
         ref = self.node_helper.get_source_ref(node)
@@ -457,12 +522,74 @@ class TS2CAST(object):
 
     def visit_for(self, node: Node) -> Loop:
         ref = self.node_helper.get_source_ref(node)
+
         # Pre: left, right        
-        loop_cond_left = get_children_by_types(node, FOR_LOOP_LEFT_TYPES)
-        loop_cond_right = get_children_by_types(node, FOR_LOOP_RIGHT_TYPES)
+        loop_cond_left = get_children_by_types(node, FOR_LOOP_LEFT_TYPES)[0]
+        loop_cond_right = get_children_by_types(node, FOR_LOOP_RIGHT_TYPES)[0]
 
         # Construct pre and expr value using left and right as needed
         # need calls to "_Iterator"
+        
+        self.variable_context.push_context()
+        iterator_name = self.variable_context.generate_iterator() 
+        stop_cond_name = self.variable_context.generate_stop_condition()
+        iter_func = self.get_gromet_function_node("iter")
+        next_func = self.get_gromet_function_node("next")
+
+        loop_cond_left_cast = self.visit(loop_cond_left)
+        loop_cond_right_cast = self.visit(loop_cond_right)
+
+        loop_pre = []
+        loop_pre.append(
+            Assignment(
+                left = Var(iterator_name, "Iterator"),
+                right = Call(
+                    iter_func,
+                    arguments=[loop_cond_right_cast]
+                )
+            )
+        )
+
+        print(loop_cond_left)
+        print(loop_cond_left_cast)
+
+        loop_pre.append(
+            Assignment(
+                left=LiteralValue(
+                    "Tuple",
+                    [
+                        loop_cond_left_cast,
+                        Var(iterator_name, "Iterator"),
+                        Var(stop_cond_name, "Boolean"),
+                    ],
+                    source_code_data_type = ["Python",PYTHON_VERSION,"Tuple"],
+                    source_refs=ref
+                ),
+                right=Call(
+                    next_func,
+                    arguments=[Var(iterator_name, "Iterator")],
+                ),
+            )
+
+        )
+
+        loop_expr = Operator(
+            source_language="Python", 
+            interpreter="Python", 
+            version=PYTHON_VERSION, 
+            op="ast.Eq", 
+            operands=[
+                stop_cond_name,
+                LiteralValue(
+                    ScalarType.BOOLEAN,
+                    False,
+                    ["Python", PYTHON_VERSION, "boolean"],
+                    source_refs=ref,
+                )
+            ], 
+            source_refs=ref
+        )
+
         loop_body_node = get_children_by_types(node, "block")[0].children
         loop_body = []
         for node in loop_body_node:
@@ -472,9 +599,29 @@ class TS2CAST(object):
             elif isinstance(cast, AstNode):
                 loop_body.append(cast)
 
+        # Insert an additional call to 'next' at the end of the loop body,
+        # to facilitate looping in GroMEt 
+        loop_body.append(
+            Assignment(
+                left=LiteralValue(
+                    "Tuple",
+                    [
+                        loop_cond_left_cast,
+                        Var(iterator_name, "Iterator"),
+                        Var(stop_cond_name, "Boolean"),
+                    ],
+                ),
+                right=Call(
+                    next_func,
+                    arguments=[Var(iterator_name, "Iterator")],
+                ),
+            )
+        )
+
+        self.variable_context.pop_context()
         return Loop(
-            pre=[],
-            expr=[],
+            pre=loop_pre,
+            expr=loop_expr,
             body=loop_body,
             post=[],
             source_refs = ref
@@ -499,6 +646,14 @@ class TS2CAST(object):
             child_cast = self.visit(child)
             if child_cast:
                 return child_cast
+
+    def get_gromet_function_node(self, func_name: str) -> Name:
+        # Idealy, we would be able to create a dummy node and just call the name visitor.
+        # However, tree-sitter does not allow you to create or modify nodes, so we have to recreate the logic here.
+        if self.variable_context.is_variable(func_name):
+            return self.variable_context.get_node(func_name)
+
+        return self.variable_context.add_variable(func_name, "function", None)
             
 def get_name_node(node):
     # Given a CAST node, if it's type Var, then we extract the name node out of it

--- a/skema/program_analysis/CAST/python/ts2cast.py
+++ b/skema/program_analysis/CAST/python/ts2cast.py
@@ -241,7 +241,7 @@ class TS2CAST(object):
         if func_name.val.name == "range":
             start_step_value = LiteralValue(
                 ScalarType.INTEGER, 
-                value=1,
+                value="1",
                 source_code_data_type=["Python", PYTHON_VERSION, str(type(1))],
                 source_refs=[ref]
             )
@@ -460,7 +460,7 @@ class TS2CAST(object):
         elif literal_type == "list":
             list_items = []
             for elem in node.children:
-                cast = self.visit(cast)
+                cast = self.visit(elem)
                 if isinstance(cast, List):
                     list_items.extend(cast)
                 elif isinstance(cast, AstNode):
@@ -525,7 +525,7 @@ class TS2CAST(object):
 
         # Pre: left, right        
         loop_cond_left = get_children_by_types(node, FOR_LOOP_LEFT_TYPES)[0]
-        loop_cond_right = get_children_by_types(node, FOR_LOOP_RIGHT_TYPES)[0]
+        loop_cond_right = get_children_by_types(node, FOR_LOOP_RIGHT_TYPES)[-1]
 
         # Construct pre and expr value using left and right as needed
         # need calls to "_Iterator"
@@ -549,9 +549,6 @@ class TS2CAST(object):
                 )
             )
         )
-
-        print(loop_cond_left)
-        print(loop_cond_left_cast)
 
         loop_pre.append(
             Assignment(

--- a/skema/program_analysis/CAST2FN/visitors/cast_to_agraph_visitor.py
+++ b/skema/program_analysis/CAST2FN/visitors/cast_to_agraph_visitor.py
@@ -592,7 +592,10 @@ class CASTToAGraphVisitor(CASTVisitor):
             return node_uid
         elif node.value_type == StructureType.TUPLE:
             node_uid = uuid.uuid4()
-            self.G.add_node(node_uid, label=f"Tuple (...)")
+            self.G.add_node(node_uid, label=f"Tuple")
+            tuple_elems = self.visit_list(node.value)
+            for elem_uid in tuple_elems:
+                self.G.add_edge(node_uid, elem_uid)
             return node_uid
         elif node.value_type == None:
             node_uid = uuid.uuid4()

--- a/skema/program_analysis/tests/test_expression_cast.py
+++ b/skema/program_analysis/tests/test_expression_cast.py
@@ -66,3 +66,6 @@ def test_exp1():
     assert isinstance(asg_node.right, LiteralValue)
     assert asg_node.right.value_type == "Integer"
     assert asg_node.right.value == '3'
+
+if __name__ == "__main__": 
+    cast = generate_cast(exp0())

--- a/skema/program_analysis/tests/test_for_cast.py
+++ b/skema/program_analysis/tests/test_for_cast.py
@@ -12,9 +12,6 @@ from skema.program_analysis.CAST2FN.model.cast import (
     Operator
 )
 
-# NOTE: these examples are very trivial for the realm of recursion
-#       more complex ones will follow later as needed
-
 def for1():
     return """
 x = 7

--- a/skema/program_analysis/tests/test_for_cast.py
+++ b/skema/program_analysis/tests/test_for_cast.py
@@ -1,0 +1,291 @@
+# import json               NOTE: json and Path aren't used right now,
+# from pathlib import Path        but will be used in the future
+from skema.program_analysis.CAST.python.ts2cast import TS2CAST
+from skema.program_analysis.CAST2FN.model.cast import (
+    Assignment,
+    Var,
+    Call,
+    Name,
+    LiteralValue,
+    ModelIf,
+    Loop,
+    Operator
+)
+
+# NOTE: these examples are very trivial for the realm of recursion
+#       more complex ones will follow later as needed
+
+def for1():
+    return """
+x = 7
+for i in range(10):
+    x = x + i
+    """
+
+def for2():
+    return """
+x = 1
+for a,b in range(10):
+    x = x + a + b
+    """
+
+def for3():
+    return """
+x = 1
+L = [1,2,3]
+
+for i in L:
+    x = x + i
+    """
+
+
+def generate_cast(test_file_string):
+    # use Python to CAST
+    out_cast = TS2CAST(test_file_string, from_file=False).out_cast
+
+    return out_cast
+
+def test_for1():
+    cast = generate_cast(for1())
+
+    asg_node = cast.nodes[0].body[0]
+    loop_node = cast.nodes[0].body[1]
+
+    assert isinstance(asg_node, Assignment)
+    assert isinstance(asg_node.left, Var)
+    assert isinstance(asg_node.left.val, Name)
+    assert asg_node.left.val.name == "x"
+
+    assert isinstance(asg_node.right, LiteralValue)
+    assert asg_node.right.value_type == "Integer"
+    assert asg_node.right.value == '7'
+
+    assert isinstance(loop_node, Loop)
+    assert len(loop_node.pre) == 2
+
+    # Loop Pre
+    loop_pre = loop_node.pre
+    assert isinstance(loop_pre[0], Assignment)
+    assert isinstance(loop_pre[0].left, Var)
+    assert loop_pre[0].left.val.name == "generated_iter_0"
+
+    assert isinstance(loop_pre[0].right, Call)
+    assert loop_pre[0].right.func.name == "iter"
+    iter_args = loop_pre[0].right.arguments
+
+    assert len(iter_args) == 1
+    assert isinstance(iter_args[0], Call)
+    assert iter_args[0].func.name == "range"
+    assert len(iter_args[0].arguments) == 3
+
+    assert isinstance(iter_args[0].arguments[0], LiteralValue)
+    assert iter_args[0].arguments[0].value == "1"
+    assert isinstance(iter_args[0].arguments[1], LiteralValue)
+    assert iter_args[0].arguments[1].value == "10"
+    assert isinstance(iter_args[0].arguments[2], LiteralValue)
+    assert iter_args[0].arguments[2].value == "1"
+
+    assert isinstance(loop_pre[1], Assignment)
+    assert isinstance(loop_pre[1].left, LiteralValue)
+    assert loop_pre[1].left.value_type == "Tuple"
+
+    assert isinstance(loop_pre[1].left.value[0], Var)
+    assert loop_pre[1].left.value[0].val.name == "i"
+    assert isinstance(loop_pre[1].left.value[1], Var)
+    assert loop_pre[1].left.value[1].val.name == "generated_iter_0"
+    assert isinstance(loop_pre[1].left.value[2], Var)
+    assert loop_pre[1].left.value[2].val.name == "sc_0"
+    
+    assert isinstance(loop_pre[1].right, Call)
+    assert loop_pre[1].right.func.name == "next"
+    assert len(loop_pre[1].right.arguments) == 1
+    assert loop_pre[1].right.arguments[0].val.name == "generated_iter_0"
+
+    # Loop Test
+    loop_test = loop_node.expr 
+    assert isinstance(loop_test, Operator)
+    assert loop_test.op == "ast.Eq"
+    assert isinstance(loop_test.operands[0], Name)
+    assert loop_test.operands[0].name == "sc_0"
+
+    assert isinstance(loop_test.operands[1], LiteralValue)
+    assert loop_test.operands[1].value_type == "Boolean"
+
+    # Loop Body
+    loop_body = loop_node.body
+    next_call = loop_body[-1]
+    assert isinstance(next_call, Assignment)
+    assert isinstance(next_call.right, Call)
+    assert next_call.right.func.name == "next"
+    assert next_call.right.arguments[0].val.name == "generated_iter_0"
+
+
+def test_for2():
+    cast = generate_cast(for2())
+
+    asg_node = cast.nodes[0].body[0]
+    loop_node = cast.nodes[0].body[1]
+
+    assert isinstance(asg_node, Assignment)
+    assert isinstance(asg_node.left, Var)
+    assert isinstance(asg_node.left.val, Name)
+    assert asg_node.left.val.name == "x"
+
+    assert isinstance(asg_node.right, LiteralValue)
+    assert asg_node.right.value_type == "Integer"
+    assert asg_node.right.value == '1'
+
+    assert isinstance(loop_node, Loop)
+    assert len(loop_node.pre) == 2
+
+    # Loop Pre
+    loop_pre = loop_node.pre
+    assert isinstance(loop_pre[0], Assignment)
+    assert isinstance(loop_pre[0].left, Var)
+    assert loop_pre[0].left.val.name == "generated_iter_0"
+
+    assert isinstance(loop_pre[0].right, Call)
+    assert loop_pre[0].right.func.name == "iter"
+    iter_args = loop_pre[0].right.arguments
+
+    assert len(iter_args) == 1
+    assert isinstance(iter_args[0], Call)
+    assert iter_args[0].func.name == "range"
+    assert len(iter_args[0].arguments) == 3
+
+    assert isinstance(iter_args[0].arguments[0], LiteralValue)
+    assert iter_args[0].arguments[0].value == "1"
+    assert isinstance(iter_args[0].arguments[1], LiteralValue)
+    assert iter_args[0].arguments[1].value == "10"
+    assert isinstance(iter_args[0].arguments[2], LiteralValue)
+    assert iter_args[0].arguments[2].value == "1"
+
+    assert isinstance(loop_pre[1], Assignment)
+    assert isinstance(loop_pre[1].left, LiteralValue)
+    assert loop_pre[1].left.value_type == "Tuple"
+
+    assert isinstance(loop_pre[1].left.value[0], LiteralValue)
+    assert loop_pre[1].left.value[0].value_type == "Tuple"
+
+    assert isinstance(loop_pre[1].left.value[0].value[0], Var)
+    assert loop_pre[1].left.value[0].value[0].val.name == "a"
+    assert isinstance(loop_pre[1].left.value[0].value[1], Var)
+    assert loop_pre[1].left.value[0].value[1].val.name == "b"
+
+    assert isinstance(loop_pre[1].left.value[1], Var)
+    assert loop_pre[1].left.value[1].val.name == "generated_iter_0"
+    assert isinstance(loop_pre[1].left.value[2], Var)
+    assert loop_pre[1].left.value[2].val.name == "sc_0"
+    
+    assert isinstance(loop_pre[1].right, Call)
+    assert loop_pre[1].right.func.name == "next"
+    assert len(loop_pre[1].right.arguments) == 1
+    assert loop_pre[1].right.arguments[0].val.name == "generated_iter_0"
+
+    # Loop Test
+    loop_test = loop_node.expr 
+    assert isinstance(loop_test, Operator)
+    assert loop_test.op == "ast.Eq"
+    assert isinstance(loop_test.operands[0], Name)
+    assert loop_test.operands[0].name == "sc_0"
+
+    assert isinstance(loop_test.operands[1], LiteralValue)
+    assert loop_test.operands[1].value_type == "Boolean"
+
+    # Loop Body
+    loop_body = loop_node.body
+    body_asg = loop_body[0]
+    assert isinstance(body_asg, Assignment)
+
+    assert isinstance(body_asg.right, Operator)
+    assert isinstance(body_asg.right.operands[0], Operator)
+    assert isinstance(body_asg.right.operands[0].operands[0], Name)
+    assert body_asg.right.operands[0].operands[0].name == "x"
+
+    assert isinstance(body_asg.right.operands[0].operands[1], Name)
+    assert body_asg.right.operands[0].operands[1].name == "a"
+
+    assert isinstance(body_asg.right.operands[1], Name)
+    assert body_asg.right.operands[1].name == "b"
+
+    next_call = loop_body[-1]
+    assert isinstance(next_call, Assignment)
+    assert isinstance(next_call.right, Call)
+    assert next_call.right.func.name == "next"
+    assert next_call.right.arguments[0].val.name == "generated_iter_0"
+
+
+def test_for3():
+    cast = generate_cast(for3())
+
+    asg_node = cast.nodes[0].body[0]
+    list_node = cast.nodes[0].body[1]
+    loop_node = cast.nodes[0].body[2]
+
+    assert isinstance(asg_node, Assignment)
+    assert isinstance(asg_node.left, Var)
+    assert isinstance(asg_node.left.val, Name)
+    assert asg_node.left.val.name == "x"
+
+    assert isinstance(asg_node.right, LiteralValue)
+    assert asg_node.right.value_type == "Integer"
+    assert asg_node.right.value == '1'
+
+    assert isinstance(loop_node, Loop)
+    assert len(loop_node.pre) == 2
+
+    assert isinstance(list_node, Assignment)
+    assert isinstance(list_node.left, Var)
+    assert list_node.left.val.name == "L"
+
+    assert isinstance(list_node.right, LiteralValue)
+    assert list_node.right.value_type == "List"
+
+    # Loop Pre
+    loop_pre = loop_node.pre
+    assert isinstance(loop_pre[0], Assignment)
+    assert isinstance(loop_pre[0].left, Var)
+    assert loop_pre[0].left.val.name == "generated_iter_0"
+
+    assert isinstance(loop_pre[0].right, Call)
+    assert loop_pre[0].right.func.name == "iter"
+    iter_args = loop_pre[0].right.arguments
+
+    assert len(iter_args) == 1
+    assert isinstance(iter_args[0], Var)
+    assert iter_args[0].val.name == "L"
+
+    assert isinstance(loop_pre[1], Assignment)
+    assert isinstance(loop_pre[1].left, LiteralValue)
+    assert loop_pre[1].left.value_type == "Tuple"
+
+    assert isinstance(loop_pre[1].left.value[0], Var)
+    assert loop_pre[1].left.value[0].val.name == "i"
+    assert isinstance(loop_pre[1].left.value[1], Var)
+    assert loop_pre[1].left.value[1].val.name == "generated_iter_0"
+    assert isinstance(loop_pre[1].left.value[2], Var)
+    assert loop_pre[1].left.value[2].val.name == "sc_0"
+    
+    assert isinstance(loop_pre[1].right, Call)
+    assert loop_pre[1].right.func.name == "next"
+    assert len(loop_pre[1].right.arguments) == 1
+    assert loop_pre[1].right.arguments[0].val.name == "generated_iter_0"
+
+    # Loop Test
+    loop_test = loop_node.expr 
+    assert isinstance(loop_test, Operator)
+    assert loop_test.op == "ast.Eq"
+    assert isinstance(loop_test.operands[0], Name)
+    assert loop_test.operands[0].name == "sc_0"
+
+    assert isinstance(loop_test.operands[1], LiteralValue)
+    assert loop_test.operands[1].value_type == "Boolean"
+
+    # Loop Body
+    loop_body = loop_node.body
+    next_call = loop_body[-1]
+
+    assert isinstance(next_call, Assignment)
+    assert isinstance(next_call.right, Call)
+    assert next_call.right.func.name == "next"
+    assert next_call.right.arguments[0].val.name == "generated_iter_0"

--- a/skema/program_analysis/tests/test_identifier.py
+++ b/skema/program_analysis/tests/test_identifier.py
@@ -1,0 +1,39 @@
+# import json               NOTE: json and Path aren't used right now,
+# from pathlib import Path        but will be used in the future
+from skema.program_analysis.CAST.python.ts2cast import TS2CAST
+from skema.program_analysis.CAST2FN.model.cast import (
+    Assignment,
+    Var,
+    Call,
+    Name,
+    LiteralValue,
+    ModelIf,
+    Loop,
+    Operator
+)
+
+def identifier1():
+    return """x = 2"""
+
+def generate_cast(test_file_string):
+    # use Python to CAST
+    out_cast = TS2CAST(test_file_string, from_file=False).out_cast
+
+    return out_cast
+
+
+# Tests to make sure that identifiers are correctly being generated
+def test_identifier1():
+    cast = generate_cast(identifier1())
+
+    asg_node = cast.nodes[0].body[0]
+
+    assert isinstance(asg_node, Assignment)
+    assert isinstance(asg_node.left, Var)
+    assert isinstance(asg_node.left.val, Name)
+    assert asg_node.left.val.name == "x"
+
+    assert isinstance(asg_node.right, LiteralValue)
+    assert asg_node.right.value_type == "Integer"
+    assert asg_node.right.value == '2'
+

--- a/skema/program_analysis/tests/test_while_cast.py
+++ b/skema/program_analysis/tests/test_while_cast.py
@@ -1,0 +1,149 @@
+# import json               NOTE: json and Path aren't used right now,
+# from pathlib import Path        but will be used in the future
+from skema.program_analysis.CAST.python.ts2cast import TS2CAST
+from skema.program_analysis.CAST2FN.model.cast import (
+    Assignment,
+    Var,
+    Call,
+    Name,
+    LiteralValue,
+    ModelIf,
+    Loop,
+    Operator
+)
+
+# NOTE: these examples are very trivial for the realm of recursion
+#       more complex ones will follow later as needed
+
+def while1():
+    return """
+x = 2
+while x < 5:
+    x = x + 1
+    """
+
+def while2():
+    return """
+x = 2
+y = 3
+
+while x < 5:
+    x = x + 1
+    x = x + y
+    """
+
+def generate_cast(test_file_string):
+    # use Python to CAST
+    out_cast = TS2CAST(test_file_string, from_file=False).out_cast
+
+    return out_cast
+
+def test_while1():
+    cast = generate_cast(while1())
+
+    asg_node = cast.nodes[0].body[0]
+    loop_node = cast.nodes[0].body[1]
+
+    assert isinstance(asg_node, Assignment)
+    assert isinstance(asg_node.left, Var)
+    assert isinstance(asg_node.left.val, Name)
+    assert asg_node.left.val.name == "x"
+
+    assert isinstance(asg_node.right, LiteralValue)
+    assert asg_node.right.value_type == "Integer"
+    assert asg_node.right.value == '2'
+
+    assert isinstance(loop_node, Loop)
+    assert len(loop_node.pre) == 0
+
+    # Loop Test
+    loop_test = loop_node.expr 
+    assert isinstance(loop_test, Operator)
+    assert loop_test.op == "ast.Lt"
+    assert isinstance(loop_test.operands[0], Name)
+    assert loop_test.operands[0].name == "x"
+
+    assert isinstance(loop_test.operands[1], LiteralValue)
+    assert loop_test.operands[1].value_type == "Integer"
+    assert loop_test.operands[1].value == "5"
+
+    # Loop Body
+    loop_body = loop_node.body
+    asg = loop_body[0]
+    assert isinstance(asg, Assignment)
+    assert isinstance(asg.left, Var)
+    assert asg.left.val.name == "x"
+
+    assert isinstance(asg.right, Operator)
+    assert asg.right.op == "ast.Add"
+    assert isinstance(asg.right.operands[0], Name)
+    assert isinstance(asg.right.operands[1], LiteralValue)
+    assert asg.right.operands[1].value == "1"
+
+def test_while2():
+    cast = generate_cast(while2())
+
+    asg_node = cast.nodes[0].body[0]
+    asg_node_2 = cast.nodes[0].body[1]
+    loop_node = cast.nodes[0].body[2]
+
+    assert isinstance(asg_node, Assignment)
+    assert isinstance(asg_node.left, Var)
+    assert isinstance(asg_node.left.val, Name)
+    assert asg_node.left.val.name == "x"
+
+    assert isinstance(asg_node.right, LiteralValue)
+    assert asg_node.right.value_type == "Integer"
+    assert asg_node.right.value == '2'
+
+    assert isinstance(asg_node_2, Assignment)
+    assert isinstance(asg_node_2.left, Var)
+    assert isinstance(asg_node_2.left.val, Name)
+    assert asg_node_2.left.val.name == "y"
+
+    assert isinstance(asg_node_2.right, LiteralValue)
+    assert asg_node_2.right.value_type == "Integer"
+    assert asg_node_2.right.value == '3'
+
+    assert isinstance(loop_node, Loop)
+    assert len(loop_node.pre) == 0
+
+    # Loop Test
+    loop_test = loop_node.expr 
+    assert isinstance(loop_test, Operator)
+    assert loop_test.op == "ast.Lt"
+    assert isinstance(loop_test.operands[0], Name)
+    assert loop_test.operands[0].name == "x"
+
+    assert isinstance(loop_test.operands[1], LiteralValue)
+    assert loop_test.operands[1].value_type == "Integer"
+    assert loop_test.operands[1].value == "5"
+
+    # Loop Body
+    loop_body = loop_node.body
+    asg = loop_body[0]
+    assert isinstance(asg, Assignment)
+    assert isinstance(asg.left, Var)
+    assert asg.left.val.name == "x"
+
+    assert isinstance(asg.right, Operator)
+    assert asg.right.op == "ast.Add"
+    assert isinstance(asg.right.operands[0], Name)
+    assert asg.right.operands[0].name == "x"
+
+    assert isinstance(asg.right.operands[1], LiteralValue)
+    assert asg.right.operands[1].value == "1"
+
+    asg = loop_body[1]
+    assert isinstance(asg, Assignment)
+    assert isinstance(asg.left, Var)
+    assert asg.left.val.name == "x"
+
+    assert isinstance(asg.right, Operator)
+    assert asg.right.op == "ast.Add"
+    assert isinstance(asg.right.operands[0], Name)
+    assert asg.right.operands[0].name == "x"
+
+    assert isinstance(asg.right.operands[1], Name)
+    assert asg.right.operands[1].name == "y"
+

--- a/skema/program_analysis/tests/test_while_cast.py
+++ b/skema/program_analysis/tests/test_while_cast.py
@@ -12,9 +12,6 @@ from skema.program_analysis.CAST2FN.model.cast import (
     Operator
 )
 
-# NOTE: these examples are very trivial for the realm of recursion
-#       more complex ones will follow later as needed
-
 def while1():
     return """
 x = 2


### PR DESCRIPTION
This PR introduces support for generating CAST for Loops (for/while) using tree-sitter, as part of the ongoing effort to port over the Python AST to CAST generation to using tree-sitter.

### Python Tree Sitter
- Added support for generating CAST Loop nodes using Python tree sitter.
- Specifically, we added support for Python's For and While loop CAST generation. 
- Added some support for tree-sitter "patterns: "list_pattern", "tuple_pattern", "list_pattern". These are used primarily in the For loop syntax as the item we're iterating over.
- Also added support for generating Iterator function calls, as used by the Python For Loops.
- Updated the CAST to AGraph visualizer to better visualize tuples.

### Testing 

- Added some small unit tests for loops (for/while) to determine consistency. 
- Added a small unit test for detecting missing identifiers in the first line of a Python program.

### Other Fixes
- Fixes an issue with missing identifier names when they appeared on the first line of the Python program. This was done by adding some additional handling that is specific to the first line of the program. 

Resolves #498 
Resolves #740 