### PR TITLE
Code2MET Rust Endpoint

### DIFF
--- a/skema/rest/workflows.py
+++ b/skema/rest/workflows.py
@@ -346,5 +346,33 @@ async def repo_to_rn_amr(zip_file: UploadFile = File()):
     return res.json()
 """
 
+# code snippets -> fn -> MET -> ????
+@router.post("/isa/code-align", summary="ISA aided inference")
+async def code_snippets_to_pn_amr(system: code2fn.System, client: httpx.AsyncClient = Depends(utils.get_client)):
+    gromet = await code2fn.fn_given_filepaths(system)
+    gromet, _ = utils.fn_preprocessor(gromet)
+    # print(f"gromet:{gromet}")
+    # print(f"client.follow_redirects:\t{client.follow_redirects}")
+    # print(f"client.timeout:\t{client.timeout}")
+    res = await client.put(f"{SKEMA_RS_ADDESS}/models/MET", json=gromet)
+    # res is a vector of MET's from the code (assuming it could extract correctly)
+    if res.status_code != 200:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": f"MORAE PUT /models/PN failed to process payload ({res.text})",
+                "payload": gromet,
+            },
+        )
+    
+    # Liang, if you want to put your ISA portion here?
+    # ISA:
+    #
+    #
+    #
+    #
+    return res.json()
+
+
 app = FastAPI()
 app.include_router(router)

--- a/skema/rest/workflows.py
+++ b/skema/rest/workflows.py
@@ -346,9 +346,9 @@ async def repo_to_rn_amr(zip_file: UploadFile = File()):
     return res.json()
 """
 
-# code snippets -> fn -> MET -> ????
+# code snippets -> fn -> Vec<MET> -> ????
 @router.post("/isa/code-align", summary="ISA aided inference")
-async def code_snippets_to_pn_amr(system: code2fn.System, client: httpx.AsyncClient = Depends(utils.get_client)):
+async def code_snippets_to_isa_align(system: code2fn.System, client: httpx.AsyncClient = Depends(utils.get_client)):
     gromet = await code2fn.fn_given_filepaths(system)
     gromet, _ = utils.fn_preprocessor(gromet)
     # print(f"gromet:{gromet}")

--- a/skema/rest/workflows.py
+++ b/skema/rest/workflows.py
@@ -345,7 +345,7 @@ async def repo_to_rn_amr(zip_file: UploadFile = File()):
         )
     return res.json()
 """
-
+"""
 # code snippets -> fn -> Vec<MET> -> ????
 @router.post("/isa/code-align", summary="ISA aided inference")
 async def code_snippets_to_isa_align(system: code2fn.System, client: httpx.AsyncClient = Depends(utils.get_client)):
@@ -372,7 +372,7 @@ async def code_snippets_to_isa_align(system: code2fn.System, client: httpx.Async
     #
     #
     return res.json()
-
+"""
 
 app = FastAPI()
 app.include_router(router)

--- a/skema/skema-rs/mathml/src/ast.rs
+++ b/skema/skema-rs/mathml/src/ast.rs
@@ -2,17 +2,17 @@ use derive_new::new;
 use std::fmt;
 
 pub mod operator;
-
+use serde::{Deserialize, Serialize};
 use operator::Operator;
 //use crate::ast::MathExpression::SummationOp;
 
-#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new)]
+#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new, Deserialize, Serialize)]
 pub struct Mi(pub String);
 
-#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new)]
+#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new, Deserialize, Serialize)]
 pub struct Mrow(pub Vec<MathExpression>);
 
-#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new)]
+#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new, Deserialize, Serialize)]
 pub enum Type {
     Integer,
     Rational,
@@ -28,27 +28,27 @@ pub enum Type {
     Matrix,
 }
 
-#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new)]
+#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new, Deserialize, Serialize)]
 pub struct Ci {
     pub r#type: Option<Type>,
     pub content: Box<MathExpression>,
     pub func_of: Option<Vec<Ci>>,
 }
 
-#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new)]
+#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new, Deserialize, Serialize)]
 pub struct Differential {
     pub diff: Box<MathExpression>,
     pub func: Box<MathExpression>,
 }
 
-#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new)]
+#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new, Deserialize, Serialize)]
 pub struct SummationMath {
     pub op: Box<MathExpression>,
     pub func: Box<MathExpression>,
 }
 
 /// Hat operation
-#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new)]
+#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new, Deserialize, Serialize)]
 pub struct HatComp {
     pub op: Box<MathExpression>,
     pub comp: Box<MathExpression>,
@@ -56,7 +56,7 @@ pub struct HatComp {
 
 /// The MathExpression enum is not faithful to the corresponding element type in MathML 3
 /// (https://www.w3.org/TR/MathML3/appendixa.html#parsing_MathExpression)
-#[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Hash, Default, new)]
+#[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Hash, Default, new, Deserialize, Serialize)]
 pub enum MathExpression {
     Mi(Mi),
     Mo(Operator),

--- a/skema/skema-rs/mathml/src/ast/operator.rs
+++ b/skema/skema-rs/mathml/src/ast/operator.rs
@@ -2,9 +2,10 @@ use crate::ast::Ci;
 use crate::ast::MathExpression;
 use derive_new::new;
 use std::fmt;
+use serde::{Deserialize, Serialize};
 
 /// Derivative operator, in line with Spivak notation: http://ceres-solver.org/spivak_notation.html
-#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new)]
+#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new, Deserialize, Serialize)]
 pub struct Derivative {
     pub order: u8,
     pub var_index: u8,
@@ -12,7 +13,7 @@ pub struct Derivative {
 }
 
 /// Partial derivative operator
-#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new)]
+#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new, Deserialize, Serialize)]
 pub struct PartialDerivative {
     pub order: u8,
     pub var_index: u8,
@@ -20,7 +21,7 @@ pub struct PartialDerivative {
 }
 
 /// Summation operator with under and over components
-#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new)]
+#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new, Deserialize, Serialize)]
 pub struct SumUnderOver {
     pub op: Box<MathExpression>,
     pub under: Box<MathExpression>,
@@ -28,18 +29,18 @@ pub struct SumUnderOver {
 }
 
 /// Hat operation
-#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new)]
+#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new, Deserialize, Serialize)]
 pub struct HatOp {
     pub comp: Box<MathExpression>,
 }
 
 /// Handles grad operations with subscript. E.g. ∇_{x}
-#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new)]
+#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new, Deserialize, Serialize)]
 pub struct GradSub {
     pub sub: Box<MathExpression>,
 }
 
-#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new)]
+#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new, Deserialize, Serialize)]
 pub enum Operator {
     Add,
     Multiply,

--- a/skema/skema-rs/mathml/src/parsers/math_expression_tree.rs
+++ b/skema/skema-rs/mathml/src/parsers/math_expression_tree.rs
@@ -11,7 +11,7 @@ use crate::{
 use derive_new::new;
 use nom::error::Error;
 use regex::Regex;
-
+use serde::{Deserialize, Serialize};
 use std::{fmt, str::FromStr};
 
 #[cfg(test)]
@@ -19,7 +19,7 @@ use crate::parsers::first_order_ode::{first_order_ode, FirstOrderODE};
 ///New whitespace handler before parsing
 
 /// An S-expression like structure to represent mathematical expressions.
-#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new)]
+#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Hash, new, Deserialize, Serialize)]
 pub enum MathExpressionTree {
     Atom(MathExpression),
     Cons(Operator, Vec<MathExpressionTree>),

--- a/skema/skema-rs/skema/src/bin/skema_service.rs
+++ b/skema/skema-rs/skema/src/bin/skema_service.rs
@@ -58,6 +58,7 @@ async fn main() -> std::io::Result<()> {
             gromet::get_model_RN,
             gromet::model2PN,
             gromet::model2RN,
+            gromet::model2MET,
             ping,
             version
         ),
@@ -141,6 +142,7 @@ async fn main() -> std::io::Result<()> {
             .service(gromet::get_model_RN)
             .service(gromet::model2PN)
             .service(gromet::model2RN)
+            .service(gromet::model2MET)
             .service(ping)
             .service(version)
             .service(SwaggerUi::new("/docs/{_:.*}").url("/api-doc/openapi.json", openapi.clone()))

--- a/skema/skema-rs/skema/src/services/gromet.rs
+++ b/skema/skema-rs/skema/src/services/gromet.rs
@@ -330,14 +330,13 @@ pub async fn model2RN(
     ))
 }
 
-/// This returns a RegNet AMR from a gromet.
+/// This returns a MET vector from a gromet.
 #[allow(non_snake_case)]
 #[utoipa::path(
     request_body = ModuleCollection,
     responses(
         (
-            status = 200, description = "Successfully retrieved RN AMR",
-            body = Vec<MathExpressionTree>
+            status = 200, description = "Successfully retrieved MET"
         )
     )
 )]

--- a/skema/skema-rs/skema/src/services/gromet.rs
+++ b/skema/skema-rs/skema/src/services/gromet.rs
@@ -7,6 +7,8 @@ use actix_web::web::ServiceConfig;
 use actix_web::{delete, get, post, put, web, HttpResponse};
 use mathml::acset::{PetriNet, RegNet};
 
+use mathml::ast::MathExpression;
+use mathml::parsers::math_expression_tree::MathExpressionTree;
 use neo4rs;
 use neo4rs::{query, Error, Node};
 use std::collections::HashMap;
@@ -326,4 +328,41 @@ pub async fn model2RN(
     HttpResponse::Ok().json(web::Json(
         model_to_RN(payload.into_inner(), config1).await.unwrap(),
     ))
+}
+
+/// This returns a RegNet AMR from a gromet.
+#[allow(non_snake_case)]
+#[utoipa::path(
+    request_body = ModuleCollection,
+    responses(
+        (
+            status = 200, description = "Successfully retrieved RN AMR",
+            body = Vec<MathExpressionTree>
+        )
+    )
+)]
+#[put("/models/MET")]
+pub async fn model2MET(
+    payload: web::Json<ModuleCollection>,
+    config: web::Data<Config>,
+) -> HttpResponse {
+    let config1 = Config {
+        db_host: config.db_host.clone(),
+        db_port: config.db_port,
+        db_protocol: config.db_protocol.clone(),
+    };
+    let module_id = push_model_to_db(payload.into_inner(), config1.clone()).await; // pushes model to db and gets id
+    let ref_module_id1 = module_id.as_ref();
+    let ref_module_id2 = module_id.as_ref();
+    let mathml_ast = module_id2mathml_MET_ast(*ref_module_id1.unwrap(), config1.clone()).await; // turns model into mathml ast equations
+    let _del_response = delete_module(*ref_module_id2.unwrap(), config1.clone()).await; // deletes model from db
+    let mut mets = Vec::<MathExpressionTree>::new();
+    for equation in mathml_ast.iter() {
+        let mut equal_args = Vec::<MathExpressionTree>::new();
+        equal_args.push(MathExpressionTree::Atom(MathExpression::Ci(equation.lhs_var.clone())));
+        equal_args.push(equation.rhs.clone());
+        let met = MathExpressionTree::Cons(mathml::ast::operator::Operator::Equals, equal_args.clone());
+        mets.push(met.clone());
+    }
+    HttpResponse::Ok().json(web::Json(mets))
 }


### PR DESCRIPTION
## Summary of Changes
This PR adds a new Rust side endpoint that converts gromets to a vector of MET. This will be of use as we rollout more ISA based workflows. 

This also added a commented out endpoint stub in workflows.py for taking in code-snippets and converting them into a vector of MET's as well, to further lay some foundation for ISA workflows. 

### Related issues

Resolves ???