### PR TITLE
Adding CI workflow tests

### DIFF
--- a/skema/rest/tests/test_model_to_amr.py
+++ b/skema/rest/tests/test_model_to_amr.py
@@ -11,10 +11,10 @@ from skema.rest.workflows import (
     code_snippets_to_pn_amr,
     lx_equations_to_amr
 )
+from skema.rest import schema
 from skema.rest.llm_proxy import Dynamics
 from skema.rest.proxies import SKEMA_RS_ADDESS
 from skema.skema_py import server as code2fn
-from schema import EquationLatexToAMR
 import json
 import httpx
 import pytest
@@ -231,7 +231,7 @@ async def test_any_amr_sidarthe():
 @pytest.mark.asyncio
 async def test_eq_to_regnet():
     
-    payload = EquationLatexToAMR(
+    payload = schema.EquationLatexToAMR(
         equations = [
             "\\frac{\\partial x}{\\partial t} = {\\alpha x} - {\\beta x y}",
             "\\frac{\\partial y}{\\partial t} = {\\alpha x y} - {\\gamma y}"

--- a/skema/rest/tests/test_model_to_amr.py
+++ b/skema/rest/tests/test_model_to_amr.py
@@ -14,6 +14,7 @@ from skema.rest.workflows import (
 from skema.rest.llm_proxy import Dynamics
 from skema.rest.proxies import SKEMA_RS_ADDESS
 from skema.skema_py import server as code2fn
+from schema import EquationLatexToAMR
 import json
 import httpx
 import pytest
@@ -229,13 +230,14 @@ async def test_any_amr_sidarthe():
 
 @pytest.mark.asyncio
 async def test_eq_to_regnet():
-    payload = {
-        "equations": [
+    
+    payload = EquationLatexToAMR(
+        equations = [
             "\\frac{\\partial x}{\\partial t} = {\\alpha x} - {\\beta x y}",
             "\\frac{\\partial y}{\\partial t} = {\\alpha x y} - {\\gamma y}"
         ],
-        "model": "regnet"
-        }
+        model = "regnet",
+    )
     async with httpx.AsyncClient() as client:
         regnet_amr_response = await lx_equations_to_amr(payload, client=client)
     

--- a/skema/rest/tests/test_model_to_amr.py
+++ b/skema/rest/tests/test_model_to_amr.py
@@ -9,6 +9,7 @@ from fastapi import UploadFile
 from skema.rest.workflows import (
     llm_assisted_codebase_to_pn_amr,
     code_snippets_to_pn_amr,
+    lx_equations_to_amr
 )
 from skema.rest.llm_proxy import Dynamics
 from skema.rest.proxies import SKEMA_RS_ADDESS
@@ -225,3 +226,18 @@ async def test_any_amr_sidarthe():
     print(f"final amr: {amr}\n")
     # For this test, we are just checking that AMR was generated without crashing. We are not checking for accuracy.
     assert "model" in amr, f"'model' should be in AMR response, but got {amr}"
+
+@pytest.mark.asyncio
+async def test_eq_to_regnet():
+    payload = {
+        "equations": [
+            "\\frac{\\partial x}{\\partial t} = {\\alpha x} - {\\beta x y}",
+            "\\frac{\\partial y}{\\partial t} = {\\alpha x y} - {\\gamma y}"
+        ],
+        "model": "regnet"
+        }
+    async with httpx.AsyncClient() as client:
+        regnet_amr_response = await lx_equations_to_amr(payload, client=client)
+    
+    assert "model" in regnet_amr_response, f"'model' should be in AMR response, but got {regnet_amr_response}"
+

--- a/skema/rest/workflows.py
+++ b/skema/rest/workflows.py
@@ -380,6 +380,24 @@ async def llm_assisted_codebase_to_pn_amr(zip_file: UploadFile = File(), client:
 
     return amr
 
+# code snippets -> fn -> petrinet amr
+@router.post("/code/snippets-to-MET", summary="Code snippets → MET")
+async def code_snippets_to_MET(system: code2fn.System, client: httpx.AsyncClient = Depends(utils.get_client)):
+    gromet = await code2fn.fn_given_filepaths(system)
+    gromet, _ = utils.fn_preprocessor(gromet)
+    # print(f"gromet:{gromet}")
+    # print(f"client.follow_redirects:\t{client.follow_redirects}")
+    # print(f"client.timeout:\t{client.timeout}")
+    res = await client.put(f"{SKEMA_RS_ADDESS}/models/MET", json=gromet)
+    if res.status_code != 200:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": f"MORAE PUT /models/PN failed to process payload ({res.text})",
+                "payload": gromet,
+            },
+        )
+    return res.json()
 
 """ TODO: The regnet endpoints are currently outdated
 # zip archive -> fn -> regnet amr

--- a/skema/rest/workflows.py
+++ b/skema/rest/workflows.py
@@ -156,7 +156,7 @@ async def equations_to_latex(request: Request, client: httpx.AsyncClient = Depen
 
 # tex equations -> pmml -> amr
 @router.post("/latex/equations-to-amr", summary="Equations (LaTeX) → pMML → AMR")
-async def equations_to_amr(data: schema.EquationLatexToAMR, client: httpx.AsyncClient = Depends(utils.get_client)):
+async def lx_equations_to_amr(data: schema.EquationLatexToAMR, client: httpx.AsyncClient = Depends(utils.get_client)):
     """
     Converts equations (in LaTeX) to AMR.
 


### PR DESCRIPTION
## Summary of Changes
This PR added a CI test for LaTeX to Regnet. 
It also added a new endpoint for code snippets to MathExpressionTree

### Related issues

Resolves part of issue #770 