### PR TITLE
[fortran] Support for Computed GO TO 

### DIFF
--- a/skema/program_analysis/CAST/fortran/ts2cast.py
+++ b/skema/program_analysis/CAST/fortran/ts2cast.py
@@ -419,7 +419,7 @@ class TS2CAST(object):
                     expr = Call(
                         func=self.get_gromet_function_node("_get"),
                         arguments=[
-                            CASTLiteralValue(value_type="List", value=statement_labels),
+                            CASTLiteralValue(value_type="List", value=[CASTLiteralValue(value=label, value_type="List") for label in statement_labels]),
                             self.visit(node.children[-1]),
                         ],
                     )

--- a/skema/program_analysis/CAST/fortran/ts2cast.py
+++ b/skema/program_analysis/CAST/fortran/ts2cast.py
@@ -380,15 +380,53 @@ class TS2CAST(object):
             source_refs=[self.node_helper.get_source_ref(node)],
         )
 
+    """
+     (keyword_statement [6, 6] - [6, 61]
+      (statement_label_reference [6, 13] - [6, 16])
+      (statement_label_reference [6, 18] - [6, 21])
+      (statement_label_reference [6, 23] - [6, 26])
+      (statement_label_reference [6, 28] - [6, 31])
+      (math_expression [6, 34] - [6, 61]
+        left: (call_expression [6, 34] - [6, 57]
+          (identifier [6, 34] - [6, 37])
+          (argument_list [6, 37] - [6, 57]
+            (math_expression [6, 38] - [6, 53]
+              left: (math_expression [6, 38] - [6, 49]
+                left: (parenthesized_expression [6, 38] - [6, 45]
+                  (math_expression [6, 39] - [6, 44]
+                    left: (identifier [6, 39] - [6, 40])
+                    right: (identifier [6, 43] - [6, 44])))
+                right: (identifier [6, 48] - [6, 49]))
+              right: (number_literal [6, 52] - [6, 53]))
+            (number_literal [6, 55] - [6, 56])))
+        right: (number_literal [6, 60] - [6, 61])))
+    """
+
     def visit_keyword_statement(self, node):
         # NOTE: RETURN is not the only Fortran keyword. GO TO and CONTINUE are also considered keywords
         identifier = self.node_helper.get_identifier(node).lower()
         if node.type == "keyword_statement":
             if "go to" in identifier:
-                statement_label_reference = get_first_child_by_type(node, "statement_label_reference")
+                statement_labels = [
+                    self.node_helper.get_identifier(child)
+                    for child in get_children_by_types(
+                        node, ["statement_label_reference"]
+                    )
+                ]
+                # If there are multiple statement labels, then this is a COMPUTED GO TO
+                # Those are handled as a "_get" access into a List of statement labels with the index determined by the expression
+                if len(statement_labels) > 1:
+                    expr = Call(
+                        func=self.get_gromet_function_node("_get"),
+                        arguments=[
+                            CASTLiteralValue(value_type="List", value=statement_labels),
+                            self.visit(node.children[-1]),
+                        ],
+                    )
+                    return Goto(label=None, expr=expr)
                 return Goto(
-                    label=self.node_helper.get_identifier(statement_label_reference),
-                    expr=None
+                    label=statement_labels[0],
+                    expr=None,
                 )
             if "continue" in identifier:
                 return self._visit_no_op(node)
@@ -419,10 +457,8 @@ class TS2CAST(object):
 
     def visit_statement_label(self, node):
         """Visitor for fortran statement labels"""
-        return Label(
-            label=self.node_helper.get_identifier(node)
-        )
-    
+        return Label(label=self.node_helper.get_identifier(node))
+
     def visit_fortran_builtin_statement(self, node):
         """Visitor for Fortran keywords that are not classified as keyword_statement by tree-sitter"""
         # All of the node types that fall into this category end with _statment.

--- a/skema/program_analysis/CAST2FN/ann_cast/cast_to_annotated_cast.py
+++ b/skema/program_analysis/CAST2FN/ann_cast/cast_to_annotated_cast.py
@@ -114,7 +114,7 @@ class CastToAnnotatedCastVisitor:
         
     @_visit.register
     def visit_goto(self, node: Goto):
-        expr = node.expr
+        expr = self.visit(node.expr) if node.expr != None else None
         label = node.label
         return AnnCastGoto(expr, label, node.source_refs)
         

--- a/skema/program_analysis/CAST2FN/ann_cast/to_gromet_pass.py
+++ b/skema/program_analysis/CAST2FN/ann_cast/to_gromet_pass.py
@@ -3294,7 +3294,7 @@ class ToGrometPass:
             if node.label in self.labels:
                 label_index = self.labels[node.label]
             else:
-                label_index = -1
+                label_index = 0
 
                 # Multiple gotos could reference the same label that we haven't seen
                 # So we maintain a list that we can update later
@@ -3315,7 +3315,9 @@ class ToGrometPass:
             self.visit(node.expr, goto_fn, node)
             index_comp_bf = len(goto_fn.bf)
 
-            labels = self.retrieve_labels(node.expr)
+            for idx,_ in enumerate(goto_fn.opi, 1):
+                goto_fn.pif = insert_gromet_object(goto_fn.pif, GrometPort(box=1))
+                goto_fn.wfopi = insert_gromet_object(goto_fn.wfopi, GrometWire(src=len(goto_fn.pif), tgt=idx))
 
             goto_fn.pof = insert_gromet_object(goto_fn.pof, GrometPort(box=index_comp_bf)) 
             goto_fn.opo = insert_gromet_object(goto_fn.opo, GrometPort(box=len(goto_fn.b), name="fn_idx"))

--- a/skema/program_analysis/tests/test_goto_computed.py
+++ b/skema/program_analysis/tests/test_goto_computed.py
@@ -1,0 +1,324 @@
+# import json               NOTE: json and Path aren't used right now,
+# from pathlib import Path        but will be used in the future
+from skema.program_analysis.multi_file_ingester import process_file_system
+from skema.gromet.fn import (
+    GrometFNModuleCollection,
+    FunctionType,
+)
+import ast
+from skema.program_analysis.tests.utils_test import create_temp_file, delete_temp_file
+
+from skema.program_analysis.CAST.fortran.ts2cast import TS2CAST
+from skema.program_analysis.CAST2FN.model.cast import SourceRef
+from skema.program_analysis.CAST2FN import cast
+from skema.program_analysis.CAST2FN.cast import CAST
+from skema.program_analysis.run_ann_cast_pipeline import ann_cast_pipeline
+
+def goto0():
+    return """
+PROGRAM ComputedGoTo
+      INTEGER:: a, b, c
+
+      a = 1
+      b = 2
+      c = 3
+
+      GO TO (100, 200, 300, 400), MOD((a + b) * c / 2, 4) + 1
+
+  100 PRINT *, 'Resulting choice led to label 100'
+      GO TO 500
+
+  200 PRINT *, 'Resulting choice led to label 200'
+      GO TO 500
+
+  300 PRINT *, 'Resulting choice led to label 300'
+      GO TO 500
+
+  400 PRINT *, 'Resulting choice led to label 400'
+      GO TO 500
+
+  500 PRINT *, 'End of program'
+      END PROGRAM ComputedGoTo    
+    """
+
+def goto1():
+    return """
+      SUBROUTINE EXAMPLE(DA,C,S)
+*     .. Scalar Arguments ..
+      DOUBLE PRECISION C,DA,S
+*     .. Local Scalars ..
+      DOUBLE PRECISION R,ROE
+      IF (DA.NE.10) GO TO 10
+      C = 1
+      R = 2
+      GO TO 20
+   10 C = 2
+      R = 3
+   20 DA = R
+      S = C
+      RETURN
+      END
+    """
+    
+
+def generate_gromet(test_file_string):
+    # How do we generate CAST for Fortran from here?
+    create_temp_file(test_file_string, "f95")
+
+    ts2cast = TS2CAST("temp.f95")
+    out_cast = ts2cast.out_cast[0]
+    gromet = ann_cast_pipeline(out_cast, gromet=True, to_file=False, from_obj=True)
+
+    delete_temp_file("f95")
+
+    return gromet
+
+def test_goto0():
+    goto_gromet = generate_gromet(goto0())
+    #####
+    # Checking FN containing label
+    base_fn = goto_gromet.fn
+    assert base_fn.bf[3].function_type == FunctionType.GOTO
+    assert base_fn.bf[6].function_type == FunctionType.GOTO
+    assert base_fn.bf[9].function_type == FunctionType.GOTO
+    assert base_fn.bf[12].function_type == FunctionType.GOTO
+    assert base_fn.bf[15].function_type == FunctionType.GOTO
+
+    assert base_fn.bf[4].function_type == FunctionType.LABEL
+    assert base_fn.bf[7].function_type == FunctionType.LABEL
+    assert base_fn.bf[10].function_type == FunctionType.LABEL
+    assert base_fn.bf[13].function_type == FunctionType.LABEL
+    assert base_fn.bf[16].function_type == FunctionType.LABEL
+
+    assert base_fn.pif[0].box == 4
+    assert base_fn.pif[1].box == 4
+    assert base_fn.pif[2].box == 4
+
+    assert base_fn.pif[3].box == 5
+    assert base_fn.pif[4].box == 5
+    assert base_fn.pif[5].box == 5
+
+    assert base_fn.pif[6].box == 7
+    assert base_fn.pif[7].box == 7
+    assert base_fn.pif[8].box == 7
+
+    assert base_fn.pif[9].box == 8
+    assert base_fn.pif[10].box == 8
+    assert base_fn.pif[11].box == 8
+
+    assert base_fn.pif[12].box == 10
+    assert base_fn.pif[13].box == 10
+    assert base_fn.pif[14].box == 10
+
+    assert base_fn.pif[15].box == 11
+    assert base_fn.pif[16].box == 11
+    assert base_fn.pif[17].box == 11
+
+    assert base_fn.pif[18].box == 13
+    assert base_fn.pif[19].box == 13
+    assert base_fn.pif[20].box == 13
+
+    assert base_fn.pif[21].box == 14
+    assert base_fn.pif[22].box == 14
+    assert base_fn.pif[23].box == 14
+
+    assert base_fn.pif[24].box == 16
+    assert base_fn.pif[25].box == 16
+    assert base_fn.pif[26].box == 16
+
+    assert base_fn.pif[27].box == 17
+    assert base_fn.pif[28].box == 17
+    assert base_fn.pif[29].box == 17
+
+    assert base_fn.pof[0].box == 1
+    assert base_fn.pof[1].box == 2
+    assert base_fn.pof[2].box == 3
+
+    assert base_fn.pof[3].box == 5
+    assert base_fn.pof[4].box == 5
+    assert base_fn.pof[5].box == 5
+
+    assert base_fn.pof[6].box == 8
+    assert base_fn.pof[7].box == 8
+    assert base_fn.pof[8].box == 8
+
+    assert base_fn.pof[9].box == 11
+    assert base_fn.pof[10].box == 11
+    assert base_fn.pof[11].box == 11
+
+    assert base_fn.pof[12].box == 14
+    assert base_fn.pof[13].box == 14
+    assert base_fn.pof[14].box == 14
+
+    assert base_fn.pof[15].box == 17
+    assert base_fn.pof[16].box == 17
+    assert base_fn.pof[17].box == 17
+
+
+    # First Goto computation with expression
+    #########
+    goto_expr_fn = goto_gromet.fn_array[3]
+    assert len(goto_expr_fn.bf) == 2
+    assert goto_expr_fn.bf[0].function_type == FunctionType.EXPRESSION
+    assert goto_expr_fn.bf[0].body == 6
+
+    assert goto_expr_fn.bf[1].function_type == FunctionType.LITERAL
+    assert goto_expr_fn.bf[1].value.value_type == "None"
+    assert goto_expr_fn.bf[1].value.value == "None"
+
+    assert len(goto_expr_fn.opi) == 3
+    assert goto_expr_fn.opi[0].box == 1
+    assert goto_expr_fn.opi[1].box == 1
+    assert goto_expr_fn.opi[2].box == 1
+
+    assert len(goto_expr_fn.opo) == 2
+    assert goto_expr_fn.opo[0].box == 1
+    assert goto_expr_fn.opo[0].name == "fn_idx"
+
+    assert goto_expr_fn.opo[1].box == 1
+    assert goto_expr_fn.opo[1].name == "label"
+
+    assert len(goto_expr_fn.pif) == 3
+    assert goto_expr_fn.pif[0].box == 1
+    assert goto_expr_fn.pif[1].box == 1
+    assert goto_expr_fn.pif[2].box == 1
+    
+    assert len(goto_expr_fn.pof) == 2
+    assert goto_expr_fn.pof[0].box == 1
+    assert goto_expr_fn.pof[1].box == 2
+
+    assert len(goto_expr_fn.wfopi) == 3
+    assert goto_expr_fn.wfopi[0].src == 1
+    assert goto_expr_fn.wfopi[0].tgt == 1
+
+    assert goto_expr_fn.wfopi[1].src == 2
+    assert goto_expr_fn.wfopi[1].tgt == 2
+
+    assert goto_expr_fn.wfopi[2].src == 3
+    assert goto_expr_fn.wfopi[2].tgt == 3
+
+    assert len(goto_expr_fn.wfopo) == 2
+    assert goto_expr_fn.wfopo[0].src == 1
+    assert goto_expr_fn.wfopo[0].tgt == 1
+
+    assert goto_expr_fn.wfopo[1].src == 2
+    assert goto_expr_fn.wfopo[1].tgt == 2
+    
+    #####
+    # Checking basic label computation
+    # Multiples of these exist in the FN but they're identical
+    goto_expr_fn = goto_gromet.fn_array[7]
+    assert len(goto_expr_fn.opi) == 3    
+    assert goto_expr_fn.opi[0].box == 1
+    assert goto_expr_fn.opi[1].box == 1
+    assert goto_expr_fn.opi[2].box == 1
+
+    assert len(goto_expr_fn.opo) == 2    
+    assert goto_expr_fn.opo[0].box == 1
+    assert goto_expr_fn.opo[0].name == "fn_idx"
+
+    assert goto_expr_fn.opo[1].box == 1
+    assert goto_expr_fn.opo[1].name == "label"
+    
+    # Checks the correct FN is grabbed in the label computation
+    assert len(goto_expr_fn.bf) == 2    
+    assert goto_expr_fn.bf[0].value == 0    
+    assert goto_expr_fn.bf[1].value == "500"    
+
+    assert len(goto_expr_fn.pof) == 2    
+    assert goto_expr_fn.pof[0].box == 1
+    assert goto_expr_fn.pof[1].box == 2
+    
+    assert len(goto_expr_fn.wfopo) == 2    
+    assert goto_expr_fn.wfopo[0].src == 1
+    assert goto_expr_fn.wfopo[0].tgt == 1
+
+    assert goto_expr_fn.wfopo[1].src == 2
+    assert goto_expr_fn.wfopo[1].tgt == 2
+
+    #####
+    # Checking computed label computation
+    goto_expr_fn = goto_gromet.fn_array[5]
+    assert len(goto_expr_fn.opi) == 3    
+    assert goto_expr_fn.opi[0].box == 1
+    assert goto_expr_fn.opi[1].box == 1
+    assert goto_expr_fn.opi[2].box == 1
+
+    assert len(goto_expr_fn.opo) == 1    
+    assert goto_expr_fn.opo[0].box == 1
+    
+    # Checks the label generation for the computed GOTO is correct
+    assert len(goto_expr_fn.bf) == 10
+    assert goto_expr_fn.bf[0].function_type == FunctionType.LANGUAGE_PRIMITIVE
+    assert goto_expr_fn.bf[0].name == "_get"
+
+    assert goto_expr_fn.bf[2].function_type == FunctionType.IMPORTED_METHOD
+    assert goto_expr_fn.bf[2].body == 5
+
+    assert len(goto_expr_fn.pif) == 12    
+    assert goto_expr_fn.pif[0].box == 1
+    assert goto_expr_fn.pif[1].box == 4
+    assert goto_expr_fn.pif[2].box == 4
+    assert goto_expr_fn.pif[3].box == 5
+    assert goto_expr_fn.pif[4].box == 5
+    assert goto_expr_fn.pif[5].box == 7
+    assert goto_expr_fn.pif[6].box == 7
+    assert goto_expr_fn.pif[7].box == 3
+    assert goto_expr_fn.pif[8].box == 3
+    assert goto_expr_fn.pif[9].box == 10
+    assert goto_expr_fn.pif[10].box == 10
+    assert goto_expr_fn.pif[11].box == 1
+
+    assert len(goto_expr_fn.pof) == 10    
+    assert goto_expr_fn.pof[0].box == 1
+    assert goto_expr_fn.pof[1].box == 2
+    assert goto_expr_fn.pof[2].box == 4
+    assert goto_expr_fn.pof[3].box == 5
+    assert goto_expr_fn.pof[4].box == 6
+    assert goto_expr_fn.pof[5].box == 7
+    assert goto_expr_fn.pof[6].box == 8
+    assert goto_expr_fn.pof[7].box == 3
+    assert goto_expr_fn.pof[8].box == 9
+    assert goto_expr_fn.pof[9].box == 10
+
+    assert len(goto_expr_fn.wfopi) == 3    
+    assert goto_expr_fn.wfopi[0].src == 2
+    assert goto_expr_fn.wfopi[0].tgt == 1
+
+    assert goto_expr_fn.wfopi[1].src == 3
+    assert goto_expr_fn.wfopi[1].tgt == 2
+
+    assert goto_expr_fn.wfopi[2].src == 5
+    assert goto_expr_fn.wfopi[2].tgt == 3
+
+    assert len(goto_expr_fn.wff) == 9    
+    assert goto_expr_fn.wff[0].src == 1
+    assert goto_expr_fn.wff[0].tgt == 2
+    
+    assert goto_expr_fn.wff[1].src == 4
+    assert goto_expr_fn.wff[1].tgt == 3
+
+    assert goto_expr_fn.wff[2].src == 6
+    assert goto_expr_fn.wff[2].tgt == 4
+    
+    assert goto_expr_fn.wff[3].src == 7
+    assert goto_expr_fn.wff[3].tgt == 5
+
+    assert goto_expr_fn.wff[4].src == 8
+    assert goto_expr_fn.wff[4].tgt == 6
+
+    assert goto_expr_fn.wff[5].src == 9
+    assert goto_expr_fn.wff[5].tgt == 7
+
+    assert goto_expr_fn.wff[6].src == 10
+    assert goto_expr_fn.wff[6].tgt == 8
+
+    assert goto_expr_fn.wff[7].src == 11
+    assert goto_expr_fn.wff[7].tgt == 9
+
+    assert goto_expr_fn.wff[8].src == 12
+    assert goto_expr_fn.wff[8].tgt == 10
+    
+    assert len(goto_expr_fn.wfopo) == 1    
+    assert goto_expr_fn.wfopo[0].src == 1
+    assert goto_expr_fn.wfopo[0].tgt == 1


### PR DESCRIPTION
## Summary of Changes
- Adds CAST support for ingesting Computed GO TO
- Adds support for generating GroMEt for CAST files containing Computed GO TOs. 
- Adds a test script `test_goto_computed.py` that contains a unit test for a small Fortran file that has a Computed GO TO. 
- Fixes a small issue in the Annotated CAST generation in `cast_to_annotated_cast.py`. This fix allows correct support of Computed GO TOs.
- Updates CAST Visualizer to support visualizing GO TO and Label CAST nodes.

### CAST Computed GO TO Conversion
Since the expression in Computed GO TOs evaluates to an index rather than a label, we make a small conversion to the expression in the CAST to support this. We utilize the _get Gromet function to handle this indexing.

So:
```fortran
GO TO (100,200,300,400), x+y
```
gets converted to:
```python
_get(["100", "200", "300", "400"], x+y)
``` 

### Related issues

Resolves #698 
Resolves #701 
Resolves #773 