### PR TITLE
[Equations] fix the divide error in parser

### DIFF
--- a/skema/skema-rs/mathml/src/parsers/generic_mathml.rs
+++ b/skema/skema-rs/mathml/src/parsers/generic_mathml.rs
@@ -199,7 +199,7 @@ pub fn multiply(input: Span) -> IResult<Operator> {
 }
 
 pub fn divide(input: Span) -> IResult<Operator> {
-    let (s, op) = value(Operator::Divide, alt((ws(tag("∕")), ws(tag("&#x2215;")))))(input)?;
+    let (s, op) = value(Operator::Divide, alt((ws(tag("∕")), ws(tag("/")), ws(tag("&#x2215;")))))(input)?;
     Ok((s, op))
 }
 


### PR DESCRIPTION
## Summary of Changes
Fix the parser error when handling "∕".