### PR TITLE
[CI] Pinning tree-sitter to 0.20.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies=[
     "dill==0.3.7",
     "networkx==2.8.8",
     "PyYAML",
-    "tree-sitter",
+    "tree-sitter==0.20.4",
     "neo4j==5.14.1",
     "requests",
     "beautifulsoup4", # used to remove comments etc from pMML before sending to MORAE


### PR DESCRIPTION
## Summary of Changes
On March 10th the tree-sitter Python library updated to version 0.21.0. This version breaks many of our unit tests due to changes in language initialization. 

This PR pins the version to 0.20.4, the last working version, so that the unit tests work again. 

### Related issues

Resolves ???