### PR TITLE
Regnet Bug Fixes

### DIFF
--- a/skema/skema-rs/mathml/src/acset.rs
+++ b/skema/skema-rs/mathml/src/acset.rs
@@ -929,7 +929,9 @@ impl From<Vec<FirstOrderODE>> for RegNet {
             unpaired_terms.remove(*i);
         }
 
-        for (i, t) in transition_pair.iter().enumerate() {
+        let mut trans_num = 0;
+
+        for (_i, t) in transition_pair.iter().enumerate() {
             if t.0.exp_states.len() == 1 {
                 // construct transtions for simple transtions
                 let prop = Properties {
@@ -938,22 +940,24 @@ impl From<Vec<FirstOrderODE>> for RegNet {
                     rate_constant: None,
                 };
                 let trans = RegTransition {
-                    id: format!("t{}", i.clone()),
+                    id: format!("t{}", trans_num.clone()),
                     source: Some(t.1.dyn_state.clone()),
                     target: Some(t.0.dyn_state.clone()),
                     sign: Some(true),
                     grounding: None,
                     properties: Some(prop.clone()),
                 };
+                trans_num = trans_num + 1;
                 transitions_vec.insert(trans.clone());
                 let trans = RegTransition {
-                    id: format!("t{}", i.clone()),
+                    id: format!("t{}", trans_num.clone()),
                     source: Some(t.0.dyn_state.clone()),
                     target: Some(t.1.dyn_state.clone()),
                     sign: Some(false),
                     grounding: None,
                     properties: Some(prop.clone()),
                 };
+                trans_num = trans_num + 1;
                 transitions_vec.insert(trans.clone());
             } else {
 
@@ -974,7 +978,6 @@ impl From<Vec<FirstOrderODE>> for RegNet {
                     rate_constant: None,
                 };
                 for (j, _out) in output.iter().enumerate() {
-                    let trans_num = i+j;
                     let trans = RegTransition {
                         id: format!("t{}", trans_num.clone()),
                         source: Some(t.1.exp_states[j].clone()),
@@ -984,6 +987,7 @@ impl From<Vec<FirstOrderODE>> for RegNet {
                         properties: Some(prop.clone()),
                     };
                     transitions_vec.insert(trans.clone());
+                    trans_num = trans_num + 1;
                 }
             }
         }
@@ -1015,7 +1019,6 @@ impl From<Vec<FirstOrderODE>> for RegNet {
                     }
                 }
                 for (j, _trm) in input.iter().enumerate() {
-                    let trans_num = i+j;
                     let trans = RegTransition {
                         id: format!("s{}", trans_num.clone()),
                         source: Some(input[j].clone()),
@@ -1025,6 +1028,7 @@ impl From<Vec<FirstOrderODE>> for RegNet {
                         properties: Some(prop.clone()),
                     };
                     transitions_vec.insert(trans.clone());
+                    trans_num = trans_num + 1;
                 }
             }
         }

--- a/skema/skema-rs/mathml/src/acset.rs
+++ b/skema/skema-rs/mathml/src/acset.rs
@@ -890,8 +890,8 @@ impl From<Vec<FirstOrderODE>> for RegNet {
             }
             // This adds the intial values from the state variables into the parameters vec
             let parameters = Parameter {
-                id: state.clone(),
-                name: Some(state.clone()),
+                id: r_state.initial.clone().unwrap(),
+                name: r_state.initial.clone(),
                 description: Some(format!(
                     "The total {} population at timestep 0",
                     state.clone()

--- a/skema/skema-rs/mathml/src/acset.rs
+++ b/skema/skema-rs/mathml/src/acset.rs
@@ -223,12 +223,12 @@ pub struct RegTransition {
     /// Note: source is a required field in the schema, but we make it optional since we want to
     /// reuse this schema for partial extractions as well.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub source: Option<Vec<String>>,
+    pub source: Option<String>,
 
     /// Note: target is a required field in the schema, but we make it optional since we want to
     /// reuse this schema for partial extractions as well.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub target: Option<Vec<String>>,
+    pub target: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sign: Option<bool>,
@@ -939,14 +939,24 @@ impl From<Vec<FirstOrderODE>> for RegNet {
                 };
                 let trans = RegTransition {
                     id: format!("t{}", i.clone()),
-                    source: Some([t.1.dyn_state.clone()].to_vec()),
-                    target: Some([t.0.dyn_state.clone()].to_vec()),
+                    source: Some(t.1.dyn_state.clone()),
+                    target: Some(t.0.dyn_state.clone()),
                     sign: Some(true),
                     grounding: None,
                     properties: Some(prop.clone()),
                 };
                 transitions_vec.insert(trans.clone());
+                let trans = RegTransition {
+                    id: format!("t{}", i.clone()),
+                    source: Some(t.0.dyn_state.clone()),
+                    target: Some(t.1.dyn_state.clone()),
+                    sign: Some(false),
+                    grounding: None,
+                    properties: Some(prop.clone()),
+                };
+                transitions_vec.insert(trans.clone());
             } else {
+
                 // construct transitions for complicated transitions
                 // mainly need to construct the output specially,
                 // run by clay
@@ -963,22 +973,25 @@ impl From<Vec<FirstOrderODE>> for RegNet {
                     name: t.0.parameters[0].clone(),
                     rate_constant: None,
                 };
-                let trans = RegTransition {
-                    id: format!("t{}", i.clone()),
-                    source: Some(t.1.exp_states.clone()),
-                    target: Some(output.clone()),
-                    sign: Some(true),
-                    grounding: None,
-                    properties: Some(prop.clone()),
-                };
-                transitions_vec.insert(trans.clone());
+                for (j, _out) in output.iter().enumerate() {
+                    let trans_num = i+j;
+                    let trans = RegTransition {
+                        id: format!("t{}", trans_num.clone()),
+                        source: Some(t.1.exp_states[j].clone()),
+                        target: Some(output[j].clone()),
+                        sign: Some(true),
+                        grounding: None,
+                        properties: Some(prop.clone()),
+                    };
+                    transitions_vec.insert(trans.clone());
+                }
             }
         }
 
         for (i, term) in unpaired_terms.iter().enumerate() {
             println!("Term: {:?}", term.clone());
             if term.exp_states.len() > 1 {
-                let mut output = [term.dyn_state.clone()].to_vec();
+                let mut output = term.dyn_state.clone();
                 let mut input = term.exp_states.clone();
 
                 let param_len = term.parameters.len();
@@ -991,28 +1004,28 @@ impl From<Vec<FirstOrderODE>> for RegNet {
 
                 input.sort();
                 input.dedup();
-                output.sort();
-                output.dedup();
 
                 if input.clone().len() > 1 {
                     let old_input = input.clone();
                     input = [].to_vec();
                     for term in old_input.clone().iter() {
-                        if *term != output[0] {
+                        if *term != output {
                             input.push(term.clone());
                         }
                     }
                 }
-
-                let trans = RegTransition {
-                    id: format!("s{}", i.clone()),
-                    source: Some(input.clone()),
-                    target: Some(output.clone()),
-                    sign: Some(true),
-                    grounding: None,
-                    properties: Some(prop.clone()),
-                };
-                transitions_vec.insert(trans.clone());
+                for (j, _trm) in input.iter().enumerate() {
+                    let trans_num = i+j;
+                    let trans = RegTransition {
+                        id: format!("s{}", trans_num.clone()),
+                        source: Some(input[j].clone()),
+                        target: Some(output.clone()),
+                        sign: Some(term.polarity),
+                        grounding: None,
+                        properties: Some(prop.clone()),
+                    };
+                    transitions_vec.insert(trans.clone());
+                }
             }
         }
 

--- a/skema/skema-rs/mathml/src/parsers/decapodes_serialization.rs
+++ b/skema/skema-rs/mathml/src/parsers/decapodes_serialization.rs
@@ -297,9 +297,9 @@ pub fn to_decapodes_serialization(
                 let tgt_idx = table_counts.variable_count;
                 let mut derivative_str = String::new();
                 if *notation == DerivativeNotation::LeibnizTotal {
-                    derivative_str.push_str(&*format!("D({},{})", order, bound_var));
+                    derivative_str.push_str(&format!("D({},{})", order, bound_var));
                 } else if *notation == DerivativeNotation::LeibnizPartialStandard {
-                    derivative_str.push_str(&*format!("PD({},{})", order, bound_var));
+                    derivative_str.push_str(&format!("PD({},{})", order, bound_var));
                 }
                 let unary = UnaryOperator {
                     src: to_decapodes_serialization(&rest[0], tables, table_counts),

--- a/skema/skema-rs/mathml/src/parsers/first_order_ode.rs
+++ b/skema/skema-rs/mathml/src/parsers/first_order_ode.rs
@@ -954,6 +954,7 @@ pub fn get_terms_mult(sys_states: Vec<String>, eq: Vec<MathExpressionTree>) -> P
         let mut rhs_vec = Vec::<PnTerm>::new();
 
         for arg in arg_terms.iter() {
+            println!("arg_term: {:?}", arg.clone());
             if arg.0 == 0 {
                 lhs_vec.push(arg.1.clone());
             } else {

--- a/skema/skema-rs/skema/src/bin/morae.rs
+++ b/skema/skema-rs/skema/src/bin/morae.rs
@@ -1,13 +1,14 @@
 use clap::Parser;
 
 pub use mathml::mml2pn::{ACSet, Term};
+use mathml::parsers::math_expression_tree::MathExpressionTree;
 use std::fs;
 // new imports
-use mathml::acset::{GeneralizedAMR, PetriNet};
+use mathml::acset::GeneralizedAMR;
 use neo4rs::{query, Node};
 use schemars::schema_for;
 use skema::config::Config;
-use skema::model_extraction::module_id2mathml_MET_ast;
+
 use std::env;
 
 use std::sync::Arc;
@@ -66,9 +67,13 @@ async fn main() {
             env::var("SKEMA_GRAPH_DB_HOST").unwrap_or("graphdb-bolt.askem.lum.ai".to_string());
         let db_port = env::var("SKEMA_GRAPH_DB_PORT").unwrap_or("443".to_string());
 
-        let schema = schema_for!(GeneralizedAMR);
-        let data = format!("{}", serde_json::to_string_pretty(&schema).unwrap());
-        fs::write("./schema.txt", data).expect("Unable to write file");
+        let schema_met = schema_for!(MathExpressionTree);
+        let data_met = serde_json::to_string_pretty(&schema_met).unwrap().to_string();
+        fs::write("./met_schema.txt", data_met).expect("Unable to write file");
+
+        let schema_gamr = schema_for!(GeneralizedAMR);
+        let data_gamr = serde_json::to_string_pretty(&schema_gamr).unwrap().to_string();
+        fs::write("./gamr_schema.txt", data_gamr).expect("Unable to write file");
         /*
         let config = Config {
             db_protocol: db_protocol.clone(),

--- a/skema/skema-rs/skema/src/services/mathml.rs
+++ b/skema/skema-rs/skema/src/services/mathml.rs
@@ -14,7 +14,7 @@ use mathml::{
     parsers::first_order_ode::{first_order_ode, FirstOrderODE},
 };
 use petgraph::dot::{Config, Dot};
-use serde_json::from_str;
+
 use utoipa;
 
 /// Parse MathML and return a DOT representation of the abstract syntax tree (AST)
@@ -151,7 +151,7 @@ request_body = Vec<String>,
 responses(
 (
 status = 200,
-body = Vec<String>
+body = Vec<MathExpressionTree>
 )
 )
 )]


### PR DESCRIPTION
## Summary of Changes
This addresses some bug that TA4 pointed out in our Regnet generation. Being generation of correct initial condition id's and fixing the json schema for edges, being the `source` and `target` fields are scalars and not arrays. 

### Related issues

Resolves #851 