### PR TITLE
Full Infix Notation Fix and Multiplication Tree Depth Bugfix

### DIFF
--- a/skema/skema-rs/mathml/src/acset.rs
+++ b/skema/skema-rs/mathml/src/acset.rs
@@ -846,18 +846,47 @@ impl From<Vec<FirstOrderODE>> for PetriNet {
                 transitions_vec.insert(transitions.clone());
 
                 let mut expression_string = "".to_string();
-
-                for param in t.0.parameters.clone().iter() {
-                    expression_string = format!("{}{}*", expression_string.clone(), param.clone());
-                }
-
-                let exp_len = t.0.exp_states.len();
-                for (i, exp) in t.0.exp_states.clone().iter().enumerate() {
-                    if i != exp_len - 1 {
+                // check for division
+                if t.0.expression.contains("divide") {
+                    // split on the divide, take the post div part, split on the apply
+                    // first entry on the apply split are div arguments
+                    let v: Vec<&str> = t.0.expression.split_terminator("<divide/>").collect();
+                    println!("v: {:?}", v.clone());
+                    let v2: Vec<&str> = v[1].split_terminator("</apply>").collect();
+                    println!("v2: {:?}", v2.clone());
+                    // now to split on the <ci></ci>
+                    let v3: Vec<&str> = v2[0].split_terminator("<ci>").collect();
+                    println!("v3: {:?}", v3.clone());
+                    let temp_str = format!("{}{}", v3[1], v3[2]);
+                    let v4: Vec<&str> = temp_str.split_terminator("</ci>").collect();
+                    println!("v4: {:?}", v4.clone());
+                    expression_string = format!("{}/{}", v4[0],v4[1]);
+                    for param in t.0.parameters.clone().iter() {
+                        if param != v4[0] && param != v4[1] {
+                            expression_string = format!("{}*{}", expression_string.clone(), param.clone());
+                        }
+                    }
+                    for (i, exp) in t.0.exp_states.clone().iter().enumerate() {
+                        if exp != v4[0] && exp != v4[1] {
+                            expression_string = format!("{}*{}", expression_string.clone(), exp.clone());
+                        }
+                    }
+                } else {
+                    for param in t.0.parameters.clone().iter() {
                         expression_string =
-                            format!("{}{}*", expression_string.clone(), exp.clone());
-                    } else {
-                        expression_string = format!("{}{}", expression_string.clone(), exp.clone());
+                            format!("{}{}*", expression_string.clone(), param.clone());
+                    }
+                    if !t.0.exp_states.is_empty() {
+                        let exp_len = t.0.exp_states.len() - 1;
+                        for (i, exp) in t.0.exp_states.clone().iter().enumerate() {
+                            if i != exp_len {
+                                expression_string =
+                                    format!("{}{}*", expression_string.clone(), exp.clone());
+                            } else {
+                                expression_string =
+                                    format!("{}{}", expression_string.clone(), exp.clone());
+                            }
+                        }
                     }
                 }
 
@@ -888,20 +917,48 @@ impl From<Vec<FirstOrderODE>> for PetriNet {
 
                 let mut expression_string = "".to_string();
 
-                for param in t.0.parameters.clone().iter() {
-                    expression_string = format!("{}{}*", expression_string.clone(), param.clone());
-                }
-
-                let exp_len = t.0.exp_states.len() - 1;
-                for (i, exp) in t.0.exp_states.clone().iter().enumerate() {
-                    if i != exp_len {
+                if t.0.expression.contains("divide") {
+                    // split on the divide, take the post div part, split on the apply
+                    // first entry on the apply split are div arguments
+                    let v: Vec<&str> = t.0.expression.split_terminator("<divide/>").collect();
+                    println!("v: {:?}", v.clone());
+                    let v2: Vec<&str> = v[1].split_terminator("</apply>").collect();
+                    println!("v2: {:?}", v2.clone());
+                    // now to split on the <ci></ci>
+                    let v3: Vec<&str> = v2[0].split_terminator("<ci>").collect();
+                    println!("v3: {:?}", v3.clone());
+                    let temp_str = format!("{}{}", v3[1], v3[2]);
+                    let v4: Vec<&str> = temp_str.split_terminator("</ci>").collect();
+                    println!("v4: {:?}", v4.clone());
+                    expression_string = format!("{}/{}", v4[0],v4[1]);
+                    for param in t.0.parameters.clone().iter() {
+                        if param != v4[0] && param != v4[1] {
+                            expression_string = format!("{}*{}", expression_string.clone(), param.clone());
+                        }
+                    }
+                    for (i, exp) in t.0.exp_states.clone().iter().enumerate() {
+                        if exp != v4[0] && exp != v4[1] {
+                            expression_string = format!("{}*{}", expression_string.clone(), exp.clone());
+                        }
+                    }
+                } else {
+                    for param in t.0.parameters.clone().iter() {
                         expression_string =
-                            format!("{}{}*", expression_string.clone(), exp.clone());
-                    } else {
-                        expression_string = format!("{}{}", expression_string.clone(), exp.clone());
+                            format!("{}{}*", expression_string.clone(), param.clone());
+                    }
+                    if !t.0.exp_states.is_empty() {
+                        let exp_len = t.0.exp_states.len() - 1;
+                        for (i, exp) in t.0.exp_states.clone().iter().enumerate() {
+                            if i != exp_len {
+                                expression_string =
+                                    format!("{}{}*", expression_string.clone(), exp.clone());
+                            } else {
+                                expression_string =
+                                    format!("{}{}", expression_string.clone(), exp.clone());
+                            }
+                        }
                     }
                 }
-
                 let rate = Rate {
                     target: transitions.id.clone(),
                     expression: expression_string.clone(), // the second term needs to be the product of the inputs
@@ -944,22 +1001,48 @@ impl From<Vec<FirstOrderODE>> for PetriNet {
 
                     let mut expression_string = "".to_string();
 
-                    if !term.exp_states.is_empty() {
-                        let exp_len = term.exp_states.len() - 1;
-                        for (i, exp) in term.exp_states.clone().iter().enumerate() {
-                            if i != exp_len {
-                                expression_string =
-                                    format!("{}{}*", expression_string.clone(), exp.clone());
-                            } else {
-                                expression_string =
-                                    format!("{}{}", expression_string.clone(), exp.clone());
+                    if term.expression.contains("divide") {
+                        // split on the divide, take the post div part, split on the apply
+                        // first entry on the apply split are div arguments
+                        let v: Vec<&str> = term.expression.split_terminator("<divide/>").collect();
+                        println!("v: {:?}", v.clone());
+                        let v2: Vec<&str> = v[1].split_terminator("</apply>").collect();
+                        println!("v2: {:?}", v2.clone());
+                        // now to split on the <ci></ci>
+                        let v3: Vec<&str> = v2[0].split_terminator("<ci>").collect();
+                        println!("v3: {:?}", v3.clone());
+                        let temp_str = format!("{}{}", v3[1], v3[2]);
+                        let v4: Vec<&str> = temp_str.split_terminator("</ci>").collect();
+                        println!("v4: {:?}", v4.clone());
+                        expression_string = format!("{}/{}", v4[0],v4[1]);
+                        for param in term.parameters.clone().iter() {
+                            if param != v4[0] && param != v4[1] {
+                                expression_string = format!("{}*{}", expression_string.clone(), param.clone());
                             }
                         }
-                    }
-
-                    for param in term.parameters.clone().iter() {
-                        expression_string =
-                            format!("{}{}", expression_string.clone(), param.clone());
+                        for (i, exp) in term.exp_states.clone().iter().enumerate() {
+                            if exp != v4[0] && exp != v4[1] {
+                                expression_string = format!("{}*{}", expression_string.clone(), exp.clone());
+                            }
+                        }
+                    } else {
+                        for param in term.parameters.clone().iter() {
+                            expression_string =
+                                format!("{}{}*", expression_string.clone(), param.clone());
+                        }
+                        if !term.exp_states.is_empty() {
+                            let exp_len = term.exp_states.len() - 1;
+                            for (i, exp) in term.exp_states.clone().iter().enumerate() {
+                                if i != exp_len {
+                                    expression_string =
+                                        format!("{}{}*", expression_string.clone(), exp.clone());
+                                } else {
+                                    expression_string =
+                                        format!("{}{}", expression_string.clone(), exp.clone());
+                                }
+                            }
+                        }
+    
                     }
 
                     let rate = Rate {
@@ -985,22 +1068,49 @@ impl From<Vec<FirstOrderODE>> for PetriNet {
 
                     let mut expression_string = "".to_string();
 
-                    if !term.exp_states.is_empty() {
-                        let exp_len = term.exp_states.len() - 1;
-                        for (i, exp) in term.exp_states.clone().iter().enumerate() {
-                            if i != exp_len {
-                                expression_string =
-                                    format!("{}{}*", expression_string.clone(), exp.clone());
-                            } else {
-                                expression_string =
-                                    format!("{}{}", expression_string.clone(), exp.clone());
+                    if term.expression.contains("divide") {
+                        // split on the divide, take the post div part, split on the apply
+                        // first entry on the apply split are div arguments
+                        let v: Vec<&str> = term.expression.split_terminator("<divide/>").collect();
+                        println!("v: {:?}", v.clone());
+                        let v2: Vec<&str> = v[1].split_terminator("</apply>").collect();
+                        println!("v2: {:?}", v2.clone());
+                        // now to split on the <ci></ci>
+                        let v3: Vec<&str> = v2[0].split_terminator("<ci>").collect();
+                        println!("v3: {:?}", v3.clone());
+                        let temp_str = format!("{}{}", v3[1], v3[2]);
+                        let v4: Vec<&str> = temp_str.split_terminator("</ci>").collect();
+                        println!("v4: {:?}", v4.clone());
+                        expression_string = format!("{}/{}", v4[0],v4[1]);
+                        for param in term.parameters.clone().iter() {
+                            if param != v4[0] && param != v4[1] {
+                                expression_string = format!("{}*{}", expression_string.clone(), param.clone());
                             }
                         }
-                    }
-
-                    for param in term.parameters.clone().iter() {
-                        expression_string =
-                            format!("{}{}", expression_string.clone(), param.clone());
+                        for (i, exp) in term.exp_states.clone().iter().enumerate() {
+                            if exp != v4[0] && exp != v4[1] {
+                                expression_string = format!("{}*{}", expression_string.clone(), exp.clone());
+                            }
+                        }
+                    } else {
+    
+                        for param in term.parameters.clone().iter() {
+                            expression_string =
+                                format!("{}{}*", expression_string.clone(), param.clone());
+                        }
+                        if !term.exp_states.is_empty() {
+                            let exp_len = term.exp_states.len() - 1;
+                            for (i, exp) in term.exp_states.clone().iter().enumerate() {
+                                if i != exp_len {
+                                    expression_string =
+                                        format!("{}{}*", expression_string.clone(), exp.clone());
+                                } else {
+                                    expression_string =
+                                        format!("{}{}", expression_string.clone(), exp.clone());
+                                }
+                            }
+                        }
+    
                     }
 
                     let rate = Rate {

--- a/skema/skema-rs/mathml/src/acset.rs
+++ b/skema/skema-rs/mathml/src/acset.rs
@@ -845,54 +845,9 @@ impl From<Vec<FirstOrderODE>> for PetriNet {
                 };
                 transitions_vec.insert(transitions.clone());
 
-                let mut expression_string = "".to_string();
-                // check for division
-                if t.0.expression.contains("divide") {
-                    // split on the divide, take the post div part, split on the apply
-                    // first entry on the apply split are div arguments
-                    let v: Vec<&str> = t.0.expression.split_terminator("<divide/>").collect();
-                    println!("v: {:?}", v.clone());
-                    let v2: Vec<&str> = v[1].split_terminator("</apply>").collect();
-                    println!("v2: {:?}", v2.clone());
-                    // now to split on the <ci></ci>
-                    let v3: Vec<&str> = v2[0].split_terminator("<ci>").collect();
-                    println!("v3: {:?}", v3.clone());
-                    let temp_str = format!("{}{}", v3[1], v3[2]);
-                    let v4: Vec<&str> = temp_str.split_terminator("</ci>").collect();
-                    println!("v4: {:?}", v4.clone());
-                    expression_string = format!("{}/{}", v4[0],v4[1]);
-                    for param in t.0.parameters.clone().iter() {
-                        if param != v4[0] && param != v4[1] {
-                            expression_string = format!("{}*{}", expression_string.clone(), param.clone());
-                        }
-                    }
-                    for (i, exp) in t.0.exp_states.clone().iter().enumerate() {
-                        if exp != v4[0] && exp != v4[1] {
-                            expression_string = format!("{}*{}", expression_string.clone(), exp.clone());
-                        }
-                    }
-                } else {
-                    for param in t.0.parameters.clone().iter() {
-                        expression_string =
-                            format!("{}{}*", expression_string.clone(), param.clone());
-                    }
-                    if !t.0.exp_states.is_empty() {
-                        let exp_len = t.0.exp_states.len() - 1;
-                        for (i, exp) in t.0.exp_states.clone().iter().enumerate() {
-                            if i != exp_len {
-                                expression_string =
-                                    format!("{}{}*", expression_string.clone(), exp.clone());
-                            } else {
-                                expression_string =
-                                    format!("{}{}", expression_string.clone(), exp.clone());
-                            }
-                        }
-                    }
-                }
-
                 let rate = Rate {
                     target: transitions.id.clone(),
-                    expression: expression_string.clone(), // the second term needs to be the product of the inputs
+                    expression: t.0.expression_infix.clone()[1..t.0.expression_infix.clone().len()-1].to_string(),// the second 
                     expression_mathml: Some(t.0.expression.clone()),
                 };
                 rate_vec.push(rate.clone());
@@ -915,53 +870,9 @@ impl From<Vec<FirstOrderODE>> for PetriNet {
                 };
                 transitions_vec.insert(transitions.clone());
 
-                let mut expression_string = "".to_string();
-
-                if t.0.expression.contains("divide") {
-                    // split on the divide, take the post div part, split on the apply
-                    // first entry on the apply split are div arguments
-                    let v: Vec<&str> = t.0.expression.split_terminator("<divide/>").collect();
-                    println!("v: {:?}", v.clone());
-                    let v2: Vec<&str> = v[1].split_terminator("</apply>").collect();
-                    println!("v2: {:?}", v2.clone());
-                    // now to split on the <ci></ci>
-                    let v3: Vec<&str> = v2[0].split_terminator("<ci>").collect();
-                    println!("v3: {:?}", v3.clone());
-                    let temp_str = format!("{}{}", v3[1], v3[2]);
-                    let v4: Vec<&str> = temp_str.split_terminator("</ci>").collect();
-                    println!("v4: {:?}", v4.clone());
-                    expression_string = format!("{}/{}", v4[0],v4[1]);
-                    for param in t.0.parameters.clone().iter() {
-                        if param != v4[0] && param != v4[1] {
-                            expression_string = format!("{}*{}", expression_string.clone(), param.clone());
-                        }
-                    }
-                    for (i, exp) in t.0.exp_states.clone().iter().enumerate() {
-                        if exp != v4[0] && exp != v4[1] {
-                            expression_string = format!("{}*{}", expression_string.clone(), exp.clone());
-                        }
-                    }
-                } else {
-                    for param in t.0.parameters.clone().iter() {
-                        expression_string =
-                            format!("{}{}*", expression_string.clone(), param.clone());
-                    }
-                    if !t.0.exp_states.is_empty() {
-                        let exp_len = t.0.exp_states.len() - 1;
-                        for (i, exp) in t.0.exp_states.clone().iter().enumerate() {
-                            if i != exp_len {
-                                expression_string =
-                                    format!("{}{}*", expression_string.clone(), exp.clone());
-                            } else {
-                                expression_string =
-                                    format!("{}{}", expression_string.clone(), exp.clone());
-                            }
-                        }
-                    }
-                }
                 let rate = Rate {
                     target: transitions.id.clone(),
-                    expression: expression_string.clone(), // the second term needs to be the product of the inputs
+                    expression: t.0.expression_infix.clone()[1..t.0.expression_infix.clone().len()-1].to_string(),// the second 
                     expression_mathml: Some(t.0.expression.clone()),
                 };
                 rate_vec.push(rate.clone());
@@ -999,55 +910,9 @@ impl From<Vec<FirstOrderODE>> for PetriNet {
                     };
                     transitions_vec.insert(transitions.clone());
 
-                    let mut expression_string = "".to_string();
-
-                    if term.expression.contains("divide") {
-                        // split on the divide, take the post div part, split on the apply
-                        // first entry on the apply split are div arguments
-                        let v: Vec<&str> = term.expression.split_terminator("<divide/>").collect();
-                        println!("v: {:?}", v.clone());
-                        let v2: Vec<&str> = v[1].split_terminator("</apply>").collect();
-                        println!("v2: {:?}", v2.clone());
-                        // now to split on the <ci></ci>
-                        let v3: Vec<&str> = v2[0].split_terminator("<ci>").collect();
-                        println!("v3: {:?}", v3.clone());
-                        let temp_str = format!("{}{}", v3[1], v3[2]);
-                        let v4: Vec<&str> = temp_str.split_terminator("</ci>").collect();
-                        println!("v4: {:?}", v4.clone());
-                        expression_string = format!("{}/{}", v4[0],v4[1]);
-                        for param in term.parameters.clone().iter() {
-                            if param != v4[0] && param != v4[1] {
-                                expression_string = format!("{}*{}", expression_string.clone(), param.clone());
-                            }
-                        }
-                        for (i, exp) in term.exp_states.clone().iter().enumerate() {
-                            if exp != v4[0] && exp != v4[1] {
-                                expression_string = format!("{}*{}", expression_string.clone(), exp.clone());
-                            }
-                        }
-                    } else {
-                        for param in term.parameters.clone().iter() {
-                            expression_string =
-                                format!("{}{}*", expression_string.clone(), param.clone());
-                        }
-                        if !term.exp_states.is_empty() {
-                            let exp_len = term.exp_states.len() - 1;
-                            for (i, exp) in term.exp_states.clone().iter().enumerate() {
-                                if i != exp_len {
-                                    expression_string =
-                                        format!("{}{}*", expression_string.clone(), exp.clone());
-                                } else {
-                                    expression_string =
-                                        format!("{}{}", expression_string.clone(), exp.clone());
-                                }
-                            }
-                        }
-    
-                    }
-
                     let rate = Rate {
                         target: transitions.id.clone(),
-                        expression: expression_string.clone(), // the second term needs to be the product of the inputs
+                        expression: term.expression_infix.clone()[1..term.expression_infix.clone().len()-1].to_string(),// the second term needs to be the product of the inputs
                         expression_mathml: Some(term.expression.clone()),
                     };
                     rate_vec.push(rate.clone());
@@ -1066,56 +931,9 @@ impl From<Vec<FirstOrderODE>> for PetriNet {
                     };
                     transitions_vec.insert(transitions.clone());
 
-                    let mut expression_string = "".to_string();
-
-                    if term.expression.contains("divide") {
-                        // split on the divide, take the post div part, split on the apply
-                        // first entry on the apply split are div arguments
-                        let v: Vec<&str> = term.expression.split_terminator("<divide/>").collect();
-                        println!("v: {:?}", v.clone());
-                        let v2: Vec<&str> = v[1].split_terminator("</apply>").collect();
-                        println!("v2: {:?}", v2.clone());
-                        // now to split on the <ci></ci>
-                        let v3: Vec<&str> = v2[0].split_terminator("<ci>").collect();
-                        println!("v3: {:?}", v3.clone());
-                        let temp_str = format!("{}{}", v3[1], v3[2]);
-                        let v4: Vec<&str> = temp_str.split_terminator("</ci>").collect();
-                        println!("v4: {:?}", v4.clone());
-                        expression_string = format!("{}/{}", v4[0],v4[1]);
-                        for param in term.parameters.clone().iter() {
-                            if param != v4[0] && param != v4[1] {
-                                expression_string = format!("{}*{}", expression_string.clone(), param.clone());
-                            }
-                        }
-                        for (i, exp) in term.exp_states.clone().iter().enumerate() {
-                            if exp != v4[0] && exp != v4[1] {
-                                expression_string = format!("{}*{}", expression_string.clone(), exp.clone());
-                            }
-                        }
-                    } else {
-    
-                        for param in term.parameters.clone().iter() {
-                            expression_string =
-                                format!("{}{}*", expression_string.clone(), param.clone());
-                        }
-                        if !term.exp_states.is_empty() {
-                            let exp_len = term.exp_states.len() - 1;
-                            for (i, exp) in term.exp_states.clone().iter().enumerate() {
-                                if i != exp_len {
-                                    expression_string =
-                                        format!("{}{}*", expression_string.clone(), exp.clone());
-                                } else {
-                                    expression_string =
-                                        format!("{}{}", expression_string.clone(), exp.clone());
-                                }
-                            }
-                        }
-    
-                    }
-
                     let rate = Rate {
                         target: transitions.id.clone(),
-                        expression: expression_string.clone(), // the second term needs to be the product of the inputs
+                        expression: term.expression_infix.clone()[1..term.expression_infix.clone().len()-1].to_string(),// the second 
                         expression_mathml: Some(term.expression.clone()),
                     };
                     rate_vec.push(rate.clone());

--- a/skema/skema-rs/mathml/src/acset.rs
+++ b/skema/skema-rs/mathml/src/acset.rs
@@ -946,6 +946,18 @@ impl From<Vec<FirstOrderODE>> for PetriNet {
         parameter_vec.sort();
         parameter_vec.dedup();
 
+        // now to trim the numbers from the parameters field
+        let mut nums = Vec::<usize>::new();
+        for (k, param) in parameter_vec.iter().enumerate() {
+            if param.id.parse::<f32>().is_ok() {
+                nums.push(k);
+            }
+        }
+
+        for num in nums.iter().rev() {
+            parameter_vec.remove(num.clone());
+        }
+
         // construct the PetriNet
         let ode = Ode {
             rates: Some(rate_vec),

--- a/skema/skema-rs/mathml/src/acset.rs
+++ b/skema/skema-rs/mathml/src/acset.rs
@@ -746,7 +746,7 @@ impl From<Vec<FirstOrderODE>> for PetriNet {
         // first is we need to replace any terms with more than 2 exp_states with subterms, these are simply
         // terms that need to be distributed (ASSUMPTION, MOST A TRANSTION CAN HAVE IS 2 IN AND 2 OUT)
         // but first we need to inherit the dynamic state to each sub term
-        let mut composite_term_ind = Vec::<usize>::new();
+        /*let mut composite_term_ind = Vec::<usize>::new();
         let mut sub_terms = Vec::<PnTerm>::new();
         for (j, t) in terms.clone().iter().enumerate() {
             if t.exp_states.len() > 2 && t.sub_terms.is_some() {
@@ -763,7 +763,7 @@ impl From<Vec<FirstOrderODE>> for PetriNet {
             terms.remove(*i);
         }
         // replace with subterms
-        terms.append(&mut sub_terms);
+        terms.append(&mut sub_terms);*/
 
         // now for polarity pairs of terms we need to construct the transistions
         let mut paired_term_indices = Vec::<usize>::new();

--- a/skema/skema-rs/mathml/src/acset.rs
+++ b/skema/skema-rs/mathml/src/acset.rs
@@ -652,6 +652,18 @@ impl From<Vec<MathExpressionTree>> for GeneralizedAMR {
             parameter_vec.push(parameter.clone());
         }
 
+        // now to trim the numbers from the parameters field
+        let mut nums = Vec::<usize>::new();
+        for (k, param) in parameter_vec.iter().enumerate() {
+            if param.id.parse::<f32>().is_ok() {
+                nums.push(k);
+            }
+        }
+
+        for num in nums.iter().rev() {
+            parameter_vec.remove(num.clone());
+        }
+
         let header = Header {
             name: "Model".to_string(),
             schema: "G-AMR".to_string(),
@@ -1210,6 +1222,18 @@ impl From<Vec<FirstOrderODE>> for RegNet {
 
         parameter_vec.sort();
         parameter_vec.dedup();
+
+        // now to trim the numbers from the parameters field
+        let mut nums = Vec::<usize>::new();
+        for (k, param) in parameter_vec.iter().enumerate() {
+            if param.id.parse::<f32>().is_ok() {
+                nums.push(k);
+            }
+        }
+
+        for num in nums.iter().rev() {
+            parameter_vec.remove(num.clone());
+        }
 
         // ------------------------------------------
 

--- a/skema/skema-rs/mathml/src/parsers/first_order_ode.rs
+++ b/skema/skema-rs/mathml/src/parsers/first_order_ode.rs
@@ -198,6 +198,7 @@ pub struct PnTerm {
     pub exp_states: Vec<String>,        // list of state variables in term
     pub polarity: bool,                 // polarity of term
     pub expression: String,             // content mathml for the expression
+    pub expression_infix: String,
     pub parameters: Vec<String>,        // list of parameters in term
     pub sub_terms: Option<Vec<PnTerm>>, // This is to handle when we need to distribute or not for terms.
     pub math_vec: Option<MathExpressionTree>, // This is to allows for easy distribution using our current frame work
@@ -263,6 +264,7 @@ pub fn get_terms(sys_states: Vec<String>, ode: FirstOrderODE) -> Vec<PnTerm> {
                     exp_states: [x.to_string().clone()].to_vec(),
                     polarity: true,
                     expression: "".to_string(),
+                    expression_infix: "".to_string(),
                     parameters: Vec::<String>::new(),
                     sub_terms: None,
                     math_vec: None,
@@ -274,6 +276,7 @@ pub fn get_terms(sys_states: Vec<String>, ode: FirstOrderODE) -> Vec<PnTerm> {
                     exp_states: Vec::<String>::new(),
                     polarity: true,
                     expression: "".to_string(),
+                    expression_infix: "".to_string(),
                     parameters: [x.to_string().clone()].to_vec(),
                     sub_terms: None,
                     math_vec: None,
@@ -380,7 +383,8 @@ pub fn get_term_power(sys_states: Vec<String>, eq: Vec<MathExpressionTree>) -> P
         dyn_state: "temp".to_string(),
         exp_states,
         polarity,
-        expression: MathExpressionTree::Cons(Multiply, eq).to_cmml(),
+        expression: MathExpressionTree::Cons(Multiply, eq.clone()).to_cmml(),
+        expression_infix: MathExpressionTree::Cons(Multiply, eq).to_infix_expression(),
         parameters: variables,
         sub_terms: None,
         math_vec: None,
@@ -442,6 +446,7 @@ pub fn get_terms_add(sys_states: Vec<String>, eq: Vec<MathExpressionTree>) -> Ve
                         exp_states: [x.to_string().clone()].to_vec(),
                         polarity: true,
                         expression: MathExpressionTree::Cons(Add, [arg.clone()].to_vec()).to_cmml(),
+                        expression_infix: MathExpressionTree::Cons(Add, [arg.clone()].to_vec()).to_infix_expression(),
                         parameters: Vec::<String>::new(),
                         sub_terms: None,
                         math_vec: Some(arg.clone()),
@@ -453,6 +458,7 @@ pub fn get_terms_add(sys_states: Vec<String>, eq: Vec<MathExpressionTree>) -> Ve
                         exp_states: Vec::<String>::new(),
                         polarity: true,
                         expression: MathExpressionTree::Cons(Add, [arg.clone()].to_vec()).to_cmml(),
+                        expression_infix: MathExpressionTree::Cons(Add, [arg.clone()].to_vec()).to_infix_expression(),
                         parameters: [x.to_string().clone()].to_vec(),
                         sub_terms: None,
                         math_vec: Some(arg.clone()),
@@ -568,6 +574,7 @@ pub fn get_terms_sub(sys_states: Vec<String>, eq: Vec<MathExpressionTree>) -> Ve
                         polarity: false,
                         expression: MathExpressionTree::Cons(Subtract, [eq[0].clone()].to_vec())
                             .to_cmml(),
+                        expression_infix: MathExpressionTree::Cons(Subtract, [eq[0].clone()].to_vec()).to_infix_expression(),
                         parameters: Vec::<String>::new(),
                         sub_terms: None,
                         math_vec: Some(eq[0].clone()),
@@ -580,6 +587,7 @@ pub fn get_terms_sub(sys_states: Vec<String>, eq: Vec<MathExpressionTree>) -> Ve
                         polarity: false,
                         expression: MathExpressionTree::Cons(Subtract, [eq[0].clone()].to_vec())
                             .to_cmml(),
+                        expression_infix: MathExpressionTree::Cons(Subtract, [eq[0].clone()].to_vec()).to_infix_expression(),
                         parameters: [x1.to_string()].to_vec(),
                         sub_terms: None,
                         math_vec: Some(eq[0].clone()),
@@ -705,10 +713,12 @@ pub fn get_terms_sub(sys_states: Vec<String>, eq: Vec<MathExpressionTree>) -> Ve
                     let mut polarity = true;
                     let mut expression =
                         MathExpressionTree::Cons(Add, [arg.clone()].to_vec()).to_cmml();
+                    let mut expression_infix = MathExpressionTree::Cons(Add, [arg.clone()].to_vec()).to_infix_expression();
                     if i == 1 {
                         polarity = false;
                         expression =
-                            MathExpressionTree::Cons(Subtract, [arg.clone()].to_vec()).to_cmml()
+                            MathExpressionTree::Cons(Subtract, [arg.clone()].to_vec()).to_cmml();
+                        expression_infix = MathExpressionTree::Cons(Subtract, [arg.clone()].to_vec()).to_infix_expression()
                     }
                     for state in sys_states.iter() {
                         if x.to_string() == *state {
@@ -721,6 +731,7 @@ pub fn get_terms_sub(sys_states: Vec<String>, eq: Vec<MathExpressionTree>) -> Ve
                             exp_states: [x.to_string().clone()].to_vec(),
                             polarity,
                             expression,
+                            expression_infix,
                             parameters: Vec::<String>::new(),
                             sub_terms: None,
                             math_vec: Some(arg.clone()),
@@ -732,6 +743,7 @@ pub fn get_terms_sub(sys_states: Vec<String>, eq: Vec<MathExpressionTree>) -> Ve
                             exp_states: Vec::<String>::new(),
                             polarity,
                             expression,
+                            expression_infix,
                             parameters: [x.to_string().clone()].to_vec(),
                             sub_terms: None,
                             math_vec: Some(arg.clone()),
@@ -836,7 +848,8 @@ pub fn get_term_div(sys_states: Vec<String>, eq: Vec<MathExpressionTree>) -> PnT
         dyn_state: "temp".to_string(),
         exp_states,
         polarity,
-        expression: MathExpressionTree::Cons(Multiply, eq).to_cmml(),
+        expression: MathExpressionTree::Cons(Multiply, eq.clone()).to_cmml(),
+        expression_infix: MathExpressionTree::Cons(Multiply, eq).to_infix_expression(),
         parameters: variables,
         sub_terms: None,
         math_vec: None,
@@ -936,6 +949,7 @@ pub fn get_terms_mult(sys_states: Vec<String>, eq: Vec<MathExpressionTree>) -> P
                             exp_states: [x.to_string().clone()].to_vec(),
                             polarity: true,
                             expression: "temp".to_string(),
+                            expression_infix: "temp".to_string(),
                             parameters: Vec::<String>::new(),
                             sub_terms: None,
                             math_vec: Some(arg.clone()),
@@ -947,6 +961,7 @@ pub fn get_terms_mult(sys_states: Vec<String>, eq: Vec<MathExpressionTree>) -> P
                             exp_states: Vec::<String>::new(),
                             polarity: true,
                             expression: "temp".to_string(),
+                            expression_infix: "temp".to_string(),
                             parameters: [x.to_string().clone()].to_vec(),
                             sub_terms: None,
                             math_vec: Some(arg.clone()),
@@ -1018,11 +1033,14 @@ pub fn get_terms_mult(sys_states: Vec<String>, eq: Vec<MathExpressionTree>) -> P
         exp_states.sort();
         //exp_states.dedup();
 
+        println!("infix expressions: {:?}\n", MathExpressionTree::Cons(Multiply, eq.clone()).to_infix_expression());
+
         PnTerm {
             dyn_state: "temp".to_string(),
             exp_states,
             polarity,
-            expression: MathExpressionTree::Cons(Multiply, eq).to_cmml(),
+            expression: MathExpressionTree::Cons(Multiply, eq.clone()).to_cmml(),
+            expression_infix: MathExpressionTree::Cons(Multiply, eq).to_infix_expression(),
             parameters: variables,
             sub_terms: Some(terms),
             math_vec: None,
@@ -1117,11 +1135,14 @@ pub fn get_term_mult(sys_states: Vec<String>, eq: Vec<MathExpressionTree>) -> Pn
     exp_states.sort();
     //exp_states.dedup();
 
+    println!("infix expressions: {:?}\n", MathExpressionTree::Cons(Multiply, eq.clone()).to_infix_expression());
+
     PnTerm {
         dyn_state: "temp".to_string(),
         exp_states,
         polarity,
-        expression: MathExpressionTree::Cons(Multiply, eq).to_cmml(),
+        expression: MathExpressionTree::Cons(Multiply, eq.clone()).to_cmml(),
+        expression_infix: MathExpressionTree::Cons(Multiply, eq).to_infix_expression(),
         parameters: variables,
         sub_terms: None,
         math_vec: None,

--- a/skema/skema-rs/mathml/src/parsers/first_order_ode.rs
+++ b/skema/skema-rs/mathml/src/parsers/first_order_ode.rs
@@ -1135,10 +1135,19 @@ pub fn flatten_mults(mut equation: MathExpressionTree) -> MathExpressionTree {
                 match y[1].clone() {
                     Cons(x1, y1) => match x1 {
                         Multiply => {
-                            let temp1 = flatten_mults(y1[0].clone());
-                            let temp2 = flatten_mults(y1[1].clone());
+                            let mut temp1 = flatten_mults(y1[0].clone());
+                            let mut temp2 = flatten_mults(y1[1].clone());
                             y.remove(1);
-                            y.append(&mut [temp1, temp2].to_vec())
+                            if let Cons(Multiply, ref mut y2) = temp1 {
+                                y.append(&mut y2.clone());
+                            } else {
+                                y.append(&mut [temp1].to_vec());
+                            }
+                            if let Cons(Multiply, ref mut y2) = temp2 {
+                                y.append(&mut y2.clone());
+                            } else {
+                                y.append(&mut [temp2].to_vec());
+                            }
                         }
                         _ => {
                             let temp1 = y[1].clone();
@@ -1151,10 +1160,19 @@ pub fn flatten_mults(mut equation: MathExpressionTree) -> MathExpressionTree {
                 match y[0].clone() {
                     Cons(x0, y0) => match x0 {
                         Multiply => {
-                            let temp1 = flatten_mults(y0[0].clone());
-                            let temp2 = flatten_mults(y0[1].clone());
+                            let mut temp1 = flatten_mults(y0[0].clone());
+                            let mut temp2 = flatten_mults(y0[1].clone());
                             y.remove(0);
-                            y.append(&mut [temp1, temp2].to_vec());
+                            if let Cons(Multiply, ref mut y2) = temp1 {
+                                y.append(&mut y2.clone());
+                            } else {
+                                y.append(&mut [temp1].to_vec());
+                            }
+                            if let Cons(Multiply, ref mut y2) = temp2 {
+                                y.append(&mut y2.clone());
+                            } else {
+                                y.append(&mut [temp2].to_vec());
+                            }
                         }
                         _ => {
                             let temp1 = y[0].clone();

--- a/skema/skema-rs/mathml/src/parsers/first_order_ode.rs
+++ b/skema/skema-rs/mathml/src/parsers/first_order_ode.rs
@@ -1033,8 +1033,6 @@ pub fn get_terms_mult(sys_states: Vec<String>, eq: Vec<MathExpressionTree>) -> P
         exp_states.sort();
         //exp_states.dedup();
 
-        println!("infix expressions: {:?}\n", MathExpressionTree::Cons(Multiply, eq.clone()).to_infix_expression());
-
         PnTerm {
             dyn_state: "temp".to_string(),
             exp_states,
@@ -1134,8 +1132,6 @@ pub fn get_term_mult(sys_states: Vec<String>, eq: Vec<MathExpressionTree>) -> Pn
     variables.dedup();
     exp_states.sort();
     //exp_states.dedup();
-
-    println!("infix expressions: {:?}\n", MathExpressionTree::Cons(Multiply, eq.clone()).to_infix_expression());
 
     PnTerm {
         dyn_state: "temp".to_string(),

--- a/skema/skema-rs/skema/src/services/mathml.rs
+++ b/skema/skema-rs/skema/src/services/mathml.rs
@@ -275,9 +275,6 @@ pub async fn get_amr(payload: web::Json<AMRmathml>) -> HttpResponse {
                 println!("pre-flattened RHS: {:?}", eq.rhs.to_string().clone());
                 eq.rhs = flatten_mults(eq.rhs.clone());
                 println!("once flattened RHS: {:?}", eq.rhs.to_string().clone());
-                eq.rhs = flatten_mults(eq.rhs.clone());
-                println!("twice flattened RHS: {:?}", eq.rhs.to_string().clone());
-                eq.rhs = flatten_mults(eq.rhs.clone());
                 flattened_asts.push(eq.clone());
             }
             let model_type = payload.model.clone();

--- a/skema/skema-rs/skema/src/services/mathml.rs
+++ b/skema/skema-rs/skema/src/services/mathml.rs
@@ -272,6 +272,11 @@ pub async fn get_amr(payload: web::Json<AMRmathml>) -> HttpResponse {
             let mut flattened_asts = Vec::<FirstOrderODE>::new();
 
             for (_, mut eq) in mt_asts {
+                println!("pre-flattened RHS: {:?}", eq.rhs.to_string().clone());
+                eq.rhs = flatten_mults(eq.rhs.clone());
+                println!("once flattened RHS: {:?}", eq.rhs.to_string().clone());
+                eq.rhs = flatten_mults(eq.rhs.clone());
+                println!("twice flattened RHS: {:?}", eq.rhs.to_string().clone());
                 eq.rhs = flatten_mults(eq.rhs.clone());
                 flattened_asts.push(eq.clone());
             }


### PR DESCRIPTION
## Summary of Changes
- Fixes an issue where when a binary multiplication tree got too deep, we failed to fully flatten it, leading to Petrinet parsing errors. 
- Fixes an error with infix expressions, so should make it so if a transition has division in it, the infix expression will properly show that as well, instead of `*` like it was showing before. 

### Related issues

Resolves #868 #871 #403 